### PR TITLE
cleanup dead links

### DIFF
--- a/Source/Fuse.Controls.Primitives/Docs/Button.md
+++ b/Source/Fuse.Controls.Primitives/Docs/Button.md
@@ -21,4 +21,4 @@ In Fuse, pretty much anything can easily be made clickable using @Clicked (and t
 		</Rectangle>
 	</App>
 
-When you click the rectangle the `Message` output will show up in the [Monitor](https://www.fusetools.com/learn/guides/preview-and-export-monitor) if you are running in preview mode. It will also show up in the standard device logs or, if you started the preview process from the commandline, in the standard console.
+When you click the rectangle the `Message` output will show up in the Monitor if you are running in preview mode. It will also show up in the standard device logs or, if you started the preview process from the commandline, in the standard console.

--- a/Source/Fuse.Reactive.Bindings/Docs/DataBindingRemarks.md
+++ b/Source/Fuse.Reactive.Bindings/Docs/DataBindingRemarks.md
@@ -96,7 +96,7 @@ You can also bind to a path:
 	</JavaScript>
 	<Text Value="{complex.user.userinfo.name}" />
 
-This is very useful when binding to arbitrary data sources such as those returned from a REST service as JSON, as it often allows you to bind directly to complex data without processing the data in code first. [See this in-depth example](https://www.fusetools.com/developers/examples/newsfeed).
+This is very useful when binding to arbitrary data sources such as those returned from a REST service as JSON, as it often allows you to bind directly to complex data without processing the data in code first. [See this in-depth example](https://fuse-open.github.io/examples/news-feed/).
 
 ## Binding directions
 


### PR DESCRIPTION
This fixes a few dead links in docs. In the case where the link is removed, there are no corresponding link in the current docs.