### PR TITLE
Make Fuse.Platform internals visible to Fuse.Views

### DIFF
--- a/Source/Fuse.Platform/Fuse.Platform.unoproj
+++ b/Source/Fuse.Platform/Fuse.Platform.unoproj
@@ -6,6 +6,7 @@
     "ProjectUrl": "https://fuse-open.github.io"
   },
   "InternalsVisibleTo": [
+    "Fuse.Views",
     "Fuse.Android",
     "Fuse.Common",
     "Fuse.Controls.Native",


### PR DESCRIPTION
This is a cherry-pick of bba6b3b123ea064fe21942851380e36eeb48329a onto release-1.9, because
a bad merge (9270031d3c337df729a99387c970d3c418e1cbd8) removed the fix. So let's get the fix
back!

Fixes #1180.