### PR TITLE
iOS: refactor uAppDelegate dep away from softkeyboard

### DIFF
--- a/Source/Fuse.Platform/Fuse.Platform.unoproj
+++ b/Source/Fuse.Platform/Fuse.Platform.unoproj
@@ -26,8 +26,8 @@
     "Android/SystemUI.uno:Source",
     "iOS/SystemUI.uno:Source",
     "iOS/SystemUI.ios.uxl:Extensions",
-    "iOS/AppDelegateSoftKeyboard.h:File",
-    "iOS/AppDelegateSoftKeyboard.mm:File",
+    "iOS/KeyboardContext.h:File",
+    "iOS/KeyboardContext.mm:File",
     "iOS/AppDelegateStatusBar.h:File",
     "iOS/AppDelegateStatusBar.mm:File"
   ]

--- a/Source/Fuse.Platform/iOS/KeyboardContext.h
+++ b/Source/Fuse.Platform/iOS/KeyboardContext.h
@@ -6,11 +6,9 @@
 #include <Uno-iOS/AppDelegate.h>
 #include <Uno-iOS/Uno-iOS.h>
 
-@(AppDelegate.HeaderFile.Declaration:Join())
-
 @{Uno.Rect:IncludeDirective}
 
-@interface uAppDelegate (SoftKeyboard)
+@interface uKeyboardContext : NSObject
 - (void)uKeyboardWillChangeFrame:(NSNotification *)notification;
 @end
 

--- a/Source/Fuse.Platform/iOS/KeyboardContext.mm
+++ b/Source/Fuse.Platform/iOS/KeyboardContext.mm
@@ -3,9 +3,9 @@
 @{Fuse.Platform.SystemUI:IncludeDirective}
 @{ObjC.Object:IncludeDirective}
 
-#include <AppDelegateSoftKeyboard.h>
+#include <KeyboardContext.h>
 
-@implementation uAppDelegate (SoftKeyboard)
+@implementation uKeyboardContext
 
 - (void)uKeyboardWillChangeFrame:(NSNotification *)notification
 {

--- a/Source/Fuse.Platform/iOS/SystemUI.ios.uxl
+++ b/Source/Fuse.Platform/iOS/SystemUI.ios.uxl
@@ -1,9 +1,9 @@
 <Extensions Backend="CPlusPlus" Condition="IOS">
 	<ProcessFile HeaderFile="AppDelegateStatusBar.h" />
 	<ProcessFile SourceFile="AppDelegateStatusBar.mm" />
-	<ProcessFile HeaderFile="AppDelegateSoftKeyboard.h" />
-	<ProcessFile SourceFile="AppDelegateSoftKeyboard.mm" />
-			
+	<ProcessFile HeaderFile="KeyboardContext.h" />
+	<ProcessFile SourceFile="KeyboardContext.mm" />
+
 	<Require Entity="Uno.Platform.TimerEventArgs" />
 	<Require Entity="Fuse.Platform.SystemUIResizeReason" />
 	<Require Entity="Fuse.Platform.SystemUI._statusBarWillChangeFrame(Uno.Platform.iOS.uCGRect, double)" />

--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -25,8 +25,8 @@ namespace Fuse.Platform
 	[Require("Source.Include", "@{Uno.Platform.iOSDisplay:Include}")]
 	[Require("Source.Include", "@{Uno.Platform.iOS.Application:Include}")]
 	[Require("Source.Include", "Uno-iOS/AppDelegate.h")]
-	[Require("Source.Include", "AppDelegateSoftKeyboard.h")]
 	[Require("Source.Include","objc/message.h")]
+	[Require("Source.Include", "KeyboardContext.h")]
 	static extern(iOS) class SystemUI
 	{
 		static Rect _bottomFrame;
@@ -82,41 +82,49 @@ namespace Fuse.Platform
 		{
 			((Uno.Platform.iOSDisplay)Uno.Platform.Displays.MainDisplay).FrameChanged += OnFrameChanged;
 			OnFrameChanged(null, null);
-			EnableKeyboardResizeNotifications();
+			EnableKeyboardResizeNotifications(_keyboardContext);
 		}
 
 		static public void OnDestroy()
 		{
-			DisableKeyboardResizeNotifications();
+			DisableKeyboardResizeNotifications(_keyboardContext);
 		}
 
+		static ObjC.Object _keyboardContext = NewKeyboardContext();
+
 		[Foreign(Language.ObjC)]
-		static void EnableKeyboardResizeNotifications()
+		static ObjC.Object NewKeyboardContext()
 		@{
-			uAppDelegate* _delegate = (uAppDelegate*)[UIApplication sharedApplication].delegate;
+			return [[uKeyboardContext alloc] init];
+		@}
+
+		[Foreign(Language.ObjC)]
+		static void EnableKeyboardResizeNotifications(ObjC.Object keyboardContext)
+		@{
+			uKeyboardContext* ctx = (uKeyboardContext*)keyboardContext;
 
 			[[NSNotificationCenter defaultCenter]
-			 addObserver:_delegate selector:@selector(uKeyboardWillChangeFrame:)
+			 addObserver:ctx selector:@selector(uKeyboardWillChangeFrame:)
 			 name:UIKeyboardWillShowNotification object:nil];
 			
 			[[NSNotificationCenter defaultCenter]
-			 addObserver:_delegate
+			 addObserver:ctx
 			 selector:@selector(uKeyboardWillChangeFrame:)
 			 name:UIKeyboardWillHideNotification object:nil];
 		@}
 
 		
 		[Foreign(Language.ObjC)]
-		static void DisableKeyboardResizeNotifications()
+		static void DisableKeyboardResizeNotifications(ObjC.Object keyboardContext)
 		@{
-			uAppDelegate* _delegate = (uAppDelegate*)[UIApplication sharedApplication].delegate;
-			
+			uKeyboardContext* ctx = (uKeyboardContext*)keyboardContext;
+
 			[[NSNotificationCenter defaultCenter]
-			 removeObserver:_delegate
+			 removeObserver:ctx
 			 name:UIKeyboardWillShowNotification object:nil];
 			
 			[[NSNotificationCenter defaultCenter]
-			 removeObserver:_delegate
+			 removeObserver:ctx
 			 name:UIKeyboardWillHideNotification object:nil];
 		@}
 


### PR DESCRIPTION
The use of Categories in objc is not a good pattern. uAppDelegate needs
to be killed. This fixes issues in fuse views where we do not have a
uAppDelegate instance

--------------------

Fixes https://github.com/fuse-open/fuselibs/issues/1172
