### PR TITLE
Fuse.Nodes: do not use KeyboardBootstrapper with Fuse.Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 ## WrapPanel / WrapLayout
 - Fixed `WrapPanel` to update its layout when a layout property changes.
 
+## Fuse.Views
+- Fixed a crash when pushing the back-button on Android.
+
 
 # 1.8
 

--- a/Source/Fuse.Nodes/MobileBootstrapping.uno
+++ b/Source/Fuse.Nodes/MobileBootstrapping.uno
@@ -17,8 +17,11 @@ namespace Fuse
 			Fuse.Platform.Lifecycle.ExitedInteractive += OnExitInteractive;
 			Fuse.Platform.Lifecycle.Terminating += OnTerminating;
 
-			Uno.Platform.EventSources.HardwareKeys.KeyDown += KeyboardBootstrapper.OnKeyPressed;
-			Uno.Platform.EventSources.HardwareKeys.KeyUp += KeyboardBootstrapper.OnKeyReleased;
+			if defined(Mobile && !Library)
+			{
+				Uno.Platform.EventSources.HardwareKeys.KeyDown += KeyboardBootstrapper.OnKeyPressed;
+				Uno.Platform.EventSources.HardwareKeys.KeyUp += KeyboardBootstrapper.OnKeyReleased;
+			}
 		}
 
 		static void OnTerminating(Fuse.Platform.ApplicationState state)


### PR DESCRIPTION
For Fuse.Views, there's no global root-viewport that can handle
input for us, unlike for normal apps. This means that we're just
going to crash down these code-paths anyway.

Fixes #1177.