### PR TITLE
Fix Push Notifications

### DIFF
--- a/Source/Fuse.PushNotifications/Android/Impl.uno
+++ b/Source/Fuse.PushNotifications/Android/Impl.uno
@@ -296,13 +296,14 @@ namespace Fuse.PushNotifications
 		[Foreign(Language.Java)]
 		static void SpitOutNotification(Java.Object _listener, string title, string body, string bigTitle, string bigBody, string notificationStyle, string featuredImage, string sound, Java.Object _payload)
 		@{
+			int id = PushNotificationReceiver.nextID();
 			Context context = (Context)_listener;
 			Bundle payload = (Bundle)_payload;
 			Intent intent = new Intent(context, @(Activity.Package).@(Activity.Name).class);
-			intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+			intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 			intent.setAction(PushNotificationReceiver.ACTION);
 			intent.replaceExtras(payload);
-			android.app.PendingIntent pendingIntent = android.app.PendingIntent.getActivity(context, 0, intent, android.app.PendingIntent.FLAG_ONE_SHOT);
+			android.app.PendingIntent pendingIntent = android.app.PendingIntent.getActivity(context, id, intent, android.app.PendingIntent.FLAG_UPDATE_CURRENT);
 			android.app.NotificationManager notificationManager = (android.app.NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
 
 			NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
@@ -318,7 +319,6 @@ namespace Fuse.PushNotifications
 				notificationBuilder.setSound(defaultSoundUri);
 			}
 
-			int id = PushNotificationReceiver.nextID();
 
 			if (notificationStyle != null && !notificationStyle.isEmpty())
 			{


### PR DESCRIPTION
Regarding to forum posts talking about a problem with unintended behavior on `Fuse.PushNotifications` that represent the following scenario : 
1- Our app received multiple notifications on the notifications bar.
2- When we click on the first one, the notification will be clickable and `` will fired also `push.on("receivedMessage" .. `.
3- The rest of notifications won't work.

I have fixed the flags for the pending intent in `Impl.uno` so that the app will receive multiple notifications and all notifications are working and doing fine