### PR TITLE
Update Fuse.PushNotifications module to work with Android 8 and keeping backward compatibility 

### DIFF
--- a/Source/Fuse.Maps/Android/MapView.uno
+++ b/Source/Fuse.Maps/Android/MapView.uno
@@ -14,7 +14,8 @@ namespace Fuse.Maps.Android
 		MOVE = 2
 	}
 
-	[Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-maps:9.2.0")]
+	[Require("Gradle.Repository", "maven { url 'https://maven.google.com' }")]
+	[Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-maps:15.0.1")]
 	extern (Android) public class MapView : Fuse.Controls.Native.Android.LeafView, IMapView
 	{
 		public bool IsReady { get; private set; }

--- a/Source/Fuse.PushNotifications/Android/GcmConstants.java
+++ b/Source/Fuse.PushNotifications/Android/GcmConstants.java
@@ -1,0 +1,76 @@
+package com.fuse.PushNotifications;
+
+public final class GcmConstants {
+    public static final String ACTION_C2DM_RECEIVE = "com.google.android.c2dm.intent.RECEIVE";
+    public static final String ACTION_C2DM_REGISTER = "com.google.android.c2dm.intent.REGISTER";
+    public static final String ACTION_C2DM_REGISTRATION = "com.google.android.c2dm.intent.REGISTRATION";
+    public static final String ACTION_C2DM_UNREGISTER = "com.google.android.c2dm.intent.UNREGISTER";
+    public static final String ACTION_GCM_SEND = "com.google.android.gcm.intent.SEND";
+    public static final String ACTION_NOTIFICATION_OPEN = "com.google.android.gms.gcm.NOTIFICATION_OPEN";
+    public static final String ACTION_NOTIFICATION_DISMISS = "com.google.android.gms.gcm.NOTIFICATION_DISMISS";
+    public static final String ACTION_SCHEDULE = "com.google.android.gms.gcm.ACTION_SCHEDULE";
+    public static final String ACTION_TASK_READY = "com.google.android.gms.gcm.ACTION_TASK_READY";
+    public static final String ACTION_TASK_INITIALZE = "com.google.android.gms.gcm.SERVICE_ACTION_INITIALIZE";
+    public static final String ACTION_INSTANCE_ID = "com.google.android.gms.iid.InstanceID";
+
+    public static final String EXTRA_APP = "app";
+    public static final String EXTRA_APP_ID = "appid";
+    public static final String EXTRA_APP_VERSION_CODE = "app_ver";
+    public static final String EXTRA_APP_VERSION_NAME = "app_ver_name";
+    public static final String EXTRA_CLIENT_VERSION = "cliv";
+    public static final String EXTRA_COMPONENT = "component";
+    public static final String EXTRA_COLLAPSE_KEY = "collapse_key";
+    public static final String EXTRA_DELAY = "google.delay";
+    public static final String EXTRA_DELETE = "delete";
+    public static final String EXTRA_ERROR = "error";
+    public static final String EXTRA_FROM = "from";
+    public static final String EXTRA_GSF_INTENT = "GSF";
+    public static final String EXTRA_GMS_VERSION = "gmsv";
+    public static final String EXTRA_IS_MESSENGER2 = "messenger2";
+    public static final String EXTRA_KID = "kid";
+    public static final String EXTRA_MESSENGER = "google.messenger";
+    public static final String EXTRA_MESSAGE_TYPE = "message_type";
+    public static final String EXTRA_MESSAGE_ID = "google.message_id";
+    public static final String EXTRA_OS_VERSION = "osv";
+    public static final String EXTRA_PENDING_INTENT = "com.google.android.gms.gcm.PENDING_INTENT";
+    public static final String EXTRA_PUBLIC_KEY = "pub2";
+    public static final String EXTRA_RAWDATA = "rawData";
+    public static final String EXTRA_RAWDATA_BASE64 = "gcm.rawData64";
+    public static final String EXTRA_REGISTRATION_ID = "registration_id";
+    public static final String EXTRA_RETRY_AFTER = "Retry-After";
+    public static final String EXTRA_SCHEDULER_ACTION = "scheduler_action";
+    public static final String EXTRA_SCOPE = "scope";
+    public static final String EXTRA_SENDER = "sender";
+    public static final String EXTRA_SENDER_LEGACY = "legacy.sender";
+    public static final String EXTRA_SEND_TO = "google.to";
+    public static final String EXTRA_SEND_FROM = "google.from";
+    public static final String EXTRA_SIGNATURE = "sig";
+    public static final String EXTRA_SUBSCIPTION = "subscription";
+    public static final String EXTRA_SUBTYPE = "subtype";
+    public static final String EXTRA_USE_GSF = "useGsf";
+    public static final String EXTRA_TAG = "tag";
+    public static final String EXTRA_TOPIC = "gcm.topic";
+    public static final String EXTRA_TTL = "google.ttl";
+    public static final String EXTRA_UNREGISTERED = "unregistered";
+
+    public static final String MESSAGE_TYPE_GCM = "gcm";
+    public static final String MESSAGE_TYPE_DELETED_MESSAGE = "deleted_message";
+    public static final String MESSAGE_TYPE_SEND_ERROR = "send_error";
+    public static final String MESSAGE_TYPE_SEND_EVENT = "send_event";
+
+    public static final String SCHEDULER_ACTION_CANCEL = "CANCEL_TASK";
+    public static final String SCHEDULER_ACTION_CANCEL_ALL = "CANCEL_ALL";
+    public static final String SCHEDULER_ACTION_SCHEDULE = "SCHEDULE_TASK";
+
+    public static final String PERMISSION_GTALK = "com.google.android.gtalkservice.permission.GTALK_SERVICE";
+    public static final String PERMISSION_NETWORK_TASK = "com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE";
+    public static final String PERMISSION_RECEIVE = "com.google.android.c2dm.permission.RECEIVE";
+    public static final String PERMISSION_SEND = "com.google.android.c2dm.permission.SEND";
+
+    public static final String ERROR_SERVICE_NOT_AVAILABLE = "SERVICE_NOT_AVAILABLE";
+
+    public static final String INSTANCE_ID_SCOPE_GCM = "GCM";
+
+    public static final String GCMID_INSTANCE_ID = "google.com/iid";
+    public static final String GCMID_REFRESH = "gcm.googleapis.com/refresh";
+}

--- a/Source/Fuse.PushNotifications/Android/Impl.cpp.uxl
+++ b/Source/Fuse.PushNotifications/Android/Impl.cpp.uxl
@@ -1,11 +1,13 @@
 <Extensions Backend="CPlusPlus" Condition="Android">
     <Require AndroidManifest.Permission="com.google.android.c2dm.permission.RECEIVE" />
+    <ProcessFile Name="PushNotificationService.java" TargetName="@(Java.SourceDirectory)/com/fuse/PushNotifications/PushNotificationService.java" />
     <ProcessFile Name="PushNotificationReceiver.java" TargetName="@(Java.SourceDirectory)/com/fuse/PushNotifications/PushNotificationReceiver.java" />
+    <ProcessFile Name="GcmConstants.java" TargetName="@(Java.SourceDirectory)/com/fuse/PushNotifications/GcmConstants.java" />
     <ProcessFile Name="BigPictureStyleHttp.java" TargetName="@(Java.SourceDirectory)/com/fuse/PushNotifications/BigPictureStyleHttp.java" />
     <ProcessFile Name="BundleFiles.java" TargetName="@(Java.SourceDirectory)/com/fuse/PushNotifications/BundleFiles.java" />
     <Require AndroidManifest.ApplicationElement><![CDATA[
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
-        <receiver android:name="com.google.android.gms.gcm.GcmReceiver"
+        <receiver android:name="com.fuse.PushNotifications.PushNotificationReceiver"
             android:exported="true"
             android:permission="com.google.android.c2dm.permission.SEND" >
             <intent-filter>
@@ -16,12 +18,9 @@
         </receiver>
 
         <service
-            android:name="com.fuse.PushNotifications.PushNotificationReceiver"
-            android:exported="false" >
-            <intent-filter>
-                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-            </intent-filter>
-        </service>
+            android:name="com.fuse.PushNotifications.PushNotificationService"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
         ]]></Require>
 
     <!-- http://iconhandbook.co.uk/reference/chart/android/ -->

--- a/Source/Fuse.PushNotifications/Android/PushNotificationReceiver.java
+++ b/Source/Fuse.PushNotifications/Android/PushNotificationReceiver.java
@@ -1,22 +1,32 @@
 package com.fuse.PushNotifications;
 
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import java.util.ArrayList;
-import com.google.android.gms.gcm.GcmListenerService;
+import com.fuse.PushNotifications.PushNotificationService;
 
-public class PushNotificationReceiver extends GcmListenerService {
+public class PushNotificationReceiver extends BroadcastReceiver {
 	public static ArrayList<Bundle> _cachedBundles = new ArrayList<Bundle>();
 	public static boolean InForeground = false;
 	public static String ACTION = "fuseBackgroundNotify";
 	static int _notificationID = -1;
 	public static int nextID() { return _notificationID += 1; }
 	private static Object lock = new Object();
-	
+
+
 	@Override
-	public void onMessageReceived(String from, Bundle bundle)
-	{
-		synchronized (lock) {
-			com.foreign.Fuse.PushNotifications.AndroidImpl.OnNotificationRecieved(this, from, bundle);
-		}
+	public void onReceive(Context context, Intent intent) {
+		Log.d("Push Notification Receiver", "Notification Received");
+	    ComponentName comp = new ComponentName(context.getPackageName(),
+	            PushNotificationService.class.getName());
+	    intent.setComponent(comp);
+	    PushNotificationService.enqueueWork(context, PushNotificationService.class, 1000, intent);
+	    setResultCode(Activity.RESULT_OK);
 	}
+
 }

--- a/Source/Fuse.PushNotifications/Android/PushNotificationService.java
+++ b/Source/Fuse.PushNotifications/Android/PushNotificationService.java
@@ -1,0 +1,136 @@
+package com.fuse.PushNotifications;
+
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.support.v4.os.AsyncTaskCompat;
+import android.util.Log;
+
+import com.google.android.gms.gcm.GcmReceiver;
+
+import android.support.v4.app.JobIntentService;
+
+import static com.fuse.PushNotifications.GcmConstants.ACTION_C2DM_RECEIVE;
+import static com.fuse.PushNotifications.GcmConstants.ACTION_NOTIFICATION_OPEN;
+import static com.fuse.PushNotifications.GcmConstants.EXTRA_ERROR;
+import static com.fuse.PushNotifications.GcmConstants.EXTRA_FROM;
+import static com.fuse.PushNotifications.GcmConstants.EXTRA_MESSAGE_ID;
+import static com.fuse.PushNotifications.GcmConstants.EXTRA_MESSAGE_TYPE;
+import static com.fuse.PushNotifications.GcmConstants.EXTRA_PENDING_INTENT;
+import static com.fuse.PushNotifications.GcmConstants.MESSAGE_TYPE_DELETED_MESSAGE;
+import static com.fuse.PushNotifications.GcmConstants.MESSAGE_TYPE_GCM;
+import static com.fuse.PushNotifications.GcmConstants.MESSAGE_TYPE_SEND_ERROR;
+import static com.fuse.PushNotifications.GcmConstants.MESSAGE_TYPE_SEND_EVENT;
+
+public class PushNotificationService extends JobIntentService{
+	private static final String TAG = "GcmListenerService";
+
+	private int startId;
+    private int counter = 0;
+    private final Object lock = new Object();
+
+    public void onDeletedMessages() {
+        // To be overwritten
+    }
+
+    public void onMessageSent(String msgId) {
+        // To be overwritten
+    }
+
+    public void onSendError(String msgId, String error) {
+        // To be overwritten
+    }
+
+	public void onMessageReceived(String from, Bundle bundle)
+	{
+        Log.d(TAG,"On Message Received");
+		synchronized (lock) {
+			com.foreign.Fuse.PushNotifications.AndroidImpl.OnNotificationRecieved(this, from, bundle);
+		}
+	}
+
+
+	@Override
+	protected void onHandleWork(Intent intent) {
+        Log.d(TAG, "handling work");
+        synchronized (lock) {
+            this.startId = startId;
+            this.counter++;
+        }
+
+        if (intent != null) {
+            Log.d(TAG, "Intent is not empty");
+            Log.d(TAG, intent.getAction()+" ");
+            if (ACTION_NOTIFICATION_OPEN.equals(intent.getAction())) {
+                handlePendingNotification(intent);
+                finishCounter();
+                GcmReceiver.completeWakefulIntent(intent);
+            } else if (ACTION_C2DM_RECEIVE.equals(intent.getAction())) {
+                final Intent newIntent = intent;
+                AsyncTaskCompat.executeParallel(new AsyncTask<Void, Void, Void>() {
+                    @Override
+                    protected Void doInBackground(Void... params) {
+                        handleC2dmMessage(newIntent);
+                        return null;
+                    }
+                });
+            } else {
+                Log.w(TAG, "Unknown intent action: " + intent.getAction());
+            }
+        } else {
+            Log.d(TAG, "Intent is empty");
+            finishCounter();
+        }
+    }
+
+    private void handleC2dmMessage(Intent intent) {
+        Log.d(TAG, "handling me");
+        try {
+            String messageType = intent.getStringExtra(EXTRA_MESSAGE_TYPE);
+            if (messageType == null || MESSAGE_TYPE_GCM.equals(messageType)) {
+                String from = intent.getStringExtra(EXTRA_FROM);
+                Bundle data = intent.getExtras();
+                data.remove(EXTRA_MESSAGE_TYPE);
+                data.remove("android.support.content.wakelockid"); // WakefulBroadcastReceiver.EXTRA_WAKE_LOCK_ID
+                data.remove(EXTRA_FROM);
+                onMessageReceived(from, data);
+            } else if (MESSAGE_TYPE_DELETED_MESSAGE.equals(messageType)) {
+                onDeletedMessages();
+            } else if (MESSAGE_TYPE_SEND_EVENT.equals(messageType)) {
+                onMessageSent(intent.getStringExtra(EXTRA_MESSAGE_ID));
+            } else if (MESSAGE_TYPE_SEND_ERROR.equals(messageType)) {
+                onSendError(intent.getStringExtra(EXTRA_MESSAGE_ID), intent.getStringExtra(EXTRA_ERROR));
+            } else {
+                Log.w(TAG, "Unknown message type: " + messageType);
+            }
+            finishCounter();
+        } finally {
+            GcmReceiver.completeWakefulIntent(intent);
+        }
+    }
+
+    private void handlePendingNotification(Intent intent) {
+        PendingIntent pendingIntent = intent.getParcelableExtra(EXTRA_PENDING_INTENT);
+        if (pendingIntent != null) {
+            try {
+                pendingIntent.send();
+            } catch (PendingIntent.CanceledException e) {
+                Log.w(TAG, "Notification cancelled", e);
+            }
+        } else {
+            Log.w(TAG, "Notification was null");
+        }
+    }
+
+    private void finishCounter() {
+        synchronized (lock) {
+            this.counter--;
+            if (counter == 0) {
+                stopSelfResult(startId);
+            }
+        }
+    }
+}

--- a/Source/Fuse.PushNotifications/Docs/Guide.md
+++ b/Source/Fuse.PushNotifications/Docs/Guide.md
@@ -24,11 +24,17 @@ Add the following to you `.unoproj`
 
     "Android": {
         ...
+        "Notification": {
+            "Name" : "App Channel Name (Normally your app name)",
+            "Description" : "App Channel Description (Normally your app description)",
+            "ChannelID": "App Unique Channel ID (Normally your app package identifier)"
+        },
         "GooglePlay": {
             "SenderID": "111781901112"
         }
         ...
     },
+**Android Oreo** and higher requires to specify a channel to group notifications, for more info please refer to [NotificationChannel Official Documentation](https://developer.android.com/training/notify-user/channels). You can define channel required info using the `Notification` block mentioned in the example above.
 
 The `SenderID` is the sender ID from the [Firebase Console](https://console.firebase.google.com).
 If you don't yet have a project set up please see the [Android setup](#android-setup) section later in this document.
@@ -135,4 +141,3 @@ Google and Apple has different limits on the size of push notifications.
 
 - Google limits to 4096 bytes
 - Apple limits to 2048 bytes on iOS 8 and up but only 256 bytes on all earlier versions
-

--- a/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
+++ b/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
@@ -30,6 +30,8 @@
     "Android/Impl.uno:Source",
     "Android/Impl.cpp.uxl:Extensions",
     "Android/PushNotificationReceiver.java:File",
+    "Android/PushNotificationService.java:File",
+    "Android/GcmConstants.java:File",
     "Android/BigPictureStyleHttp.java:File",
     "Android/BundleFiles.java:File",
     "Android/Assets/DefaultIcon.png:File"

--- a/Source/Fuse.PushNotifications/JS.uno
+++ b/Source/Fuse.PushNotifications/JS.uno
@@ -41,7 +41,7 @@ namespace Fuse.PushNotifications
 				"registrationSucceeded")
 		{
 			if (_instance != null) return;
-			Resource.SetGlobalKey(_instance = this, "FuseJS/Push");
+			Uno.UX.Resource.SetGlobalKey(_instance = this, "FuseJS/Push");
 
 			// Old-style events for backwards compatibility
 			var onReceivedMessage = new NativeEvent("onReceivedMessage");


### PR DESCRIPTION
Hello!
Previously Push Notifications caused app crashes on Android 8 because Android 8 isn't supporting background jobs anymore 

1. I made the change to use `JobIntentService` that can be scheduled and works well with all version of Android instead of plain `Service`
2. Added `NotificationChannel` logic That is required by Android 8 in order for notifications to function well.
2. updated dependencies.
3. and updated `Fuse.Maps` dependencies to avoid conflict with the new `Fuse.PushNotifications`
4. Documentation got updated accordingly.

That's all,
Thanks