### PR TITLE
Fuse.Platform: make internals visible to Fuse.Entities

### DIFF
--- a/Source/Fuse.Platform/Fuse.Platform.unoproj
+++ b/Source/Fuse.Platform/Fuse.Platform.unoproj
@@ -12,6 +12,7 @@
     "Fuse.Controls.Panels",
     "Fuse.Controls.WebView",
     "Fuse.Elements",
+    "Fuse.Entities",
     "Fuse.iOS",
     "Fuse.Nodes",
     "Fuse.Reactive.Expressions",


### PR DESCRIPTION
Otherwise we'll get build errors when using this package on mobile.

`Fuse.Entities` are using `Fuse.Platform.SystemUI.FrameChanged` here:
https://github.com/fuse-open/Fuse.Entities/blob/master/src/Scene.uno#L9

Maybe there's a better way to fix this, but this was the quickest route I found.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
