### PR TITLE
Enable loading images with binary/octet-stream content-type header

### DIFF
--- a/Source/Experimental.TextureLoader/TextureLoader.uno
+++ b/Source/Experimental.TextureLoader/TextureLoader.uno
@@ -88,6 +88,8 @@ namespace Experimental.TextureLoader
 				PngByteArrayToTexture2D(arr, callback);
 			else if (contentType.IndexOf("application/octet-stream") != -1)
 				JpegByteArrayToTexture2D(arr, callback);
+			else if (contentType.IndexOf("binary/octet-stream") != -1)
+				JpegByteArrayToTexture2D(arr, callback);
 			else
 				throw new InvalidContentTypeException(contentType);
 		}


### PR DESCRIPTION
Dear Sirs,

I have added the ability to load images with `binary/octect-stream` content type header which will increase the support of using images from different CDNs.

Best,
Ahmad