### PR TITLE
simple fix for sharing file uris to other apps

### DIFF
--- a/Source/Fuse.Share/ShareModule.uno
+++ b/Source/Fuse.Share/ShareModule.uno
@@ -145,7 +145,7 @@ namespace Fuse.Share
 				var description = args.Length>2 ? "" + args[2] : "";
 				if defined(android)
 				{
-					AndroidShareImpl.ShareFile("file://" + path, type, description);
+					AndroidShareImpl.ShareFile("content://" + path, type, description);
 					return true;
 				}
 				else if defined(iOS)


### PR DESCRIPTION
** Briefly describe changes and the motivation behind them here **
After experiencing a similar error as the one in #932 I've read the link specified there:
https://developer.android.com/reference/android/os/FileUriExposedException.html

And changed the `ShareModule.uno` file to share with the `content:///` prefix rather than `file:///`

It has fixed my problem when trying to use `shareFile()` on android.
