### PR TITLE
New camera roll features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Fuse.Deprecated.CameraView
 - This obsolete package has been removed. All functionality should be present in `Fuse.Controls.CameraView` instead.
 
+### CameraRoll
+- New feature: `checkPermissions()` - Check if your app has access to the gallery.
+- New feature: `requestPermissions()` - Request permission to access the gallery. In iOS, if the user has previously denied access this function will redirect them to your app settings in their iPhone / iPad.
+
 # 1.9
 
 ## 1.9.0

--- a/Source/Fuse.CameraRoll/CameraRoll.uno
+++ b/Source/Fuse.CameraRoll/CameraRoll.uno
@@ -57,6 +57,8 @@ namespace Fuse.CameraRoll
 			Resource.SetGlobalKey(_instance = this, "FuseJS/CameraRoll");
 			AddMember(new NativePromise<Image, Scripting.Object>("getImage", SelectPictureInterface, Image.Converter));
 			AddMember(new NativePromise<bool, Scripting.Object>("publishImage", AddToCameraRollInterface, null));
+			AddMember(new NativePromise<string, string>("checkPermissions", CheckUserPermissions, null));
+			AddMember(new NativePromise<string, string>("requestPermissions", RequestUserPermissions, null));
 		}
 
 		/**
@@ -90,6 +92,40 @@ namespace Fuse.CameraRoll
 		{
 			var Image = Image.FromObject(args[0]);
 			return AddToCameraRoll(Image);
+		}
+		
+		/**
+			@scriptmethod checkPermissions()
+
+			Checks if device has permissions to access the camera roll.
+
+			@return (Promise) a Promise that resolves if the user has permission
+		*/
+		static Future<string> CheckUserPermissions(object[] args)
+		{
+			var p = new Promise<string>();
+			if defined(Android)
+				AndroidCameraRoll.CheckPermissions(p);
+			else if defined(iOS)
+				iOSCameraRoll.CheckPermissions(p);
+			return p;
+		}
+		
+		/**
+			@scriptmethod requestPermissions()
+
+			Requests acccess to photo gallery
+
+			@return (Promise) a Promise that resolves after the user has granted permissions
+		*/
+		static Future<string> RequestUserPermissions(object[] args) 
+		{
+			var p = new Promise<string>();
+			if defined(Android)
+				AndroidCameraRoll.RequestPermissions(p);
+			else if defined(iOS)
+				iOSCameraRoll.RequestPermissions(p);
+			return p;
 		}
 
 		internal static Future<Image> SelectPicture()

--- a/Source/Fuse.CameraRoll/iOS/iOSCameraRoll.uno
+++ b/Source/Fuse.CameraRoll/iOS/iOSCameraRoll.uno
@@ -22,6 +22,18 @@ namespace Fuse.CameraRoll
 			AddToCameraRollInternal(photo.Path, cb.Resolve, cb.Reject);
 			return p;
 		}
+		
+		internal static void CheckPermissions(Promise<string> p)
+		{
+			var cb = new PromiseCallback<string>(p);
+			CheckPermissionsInternal(cb.Resolve, cb.Reject);
+		}
+		
+		internal static void RequestPermissions(Promise<string> p)
+		{
+			var cb = new PromiseCallback<string>(p);
+			RequestPermissionsInternal(cb.Resolve, cb.Reject);
+		}
 
 		internal static List<Image> ListTempImages()
 		{
@@ -59,6 +71,39 @@ namespace Fuse.CameraRoll
 				onFail(@"PHAuthorizationStatusRestricted");
 			else if (status == PHAuthorizationStatusDenied)
 				onFail(@"PHAuthorizationStatusDenied");
+		@}
+		
+		[Foreign(Language.ObjC)]
+		static void CheckPermissionsInternal(Action<string> onComplete, Action<string> onFail)
+		@{
+			PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
+			if (status == PHAuthorizationStatusAuthorized)
+				onComplete(@"PHAuthorizationStatusAuthorized");
+			else if (status == PHAuthorizationStatusNotDetermined)
+				onFail(@"PHAuthorizationStatusNotDetermined");
+			else if (status == PHAuthorizationStatusDenied)
+				onFail(@"PHAuthorizationStatusDenied");
+			else if (status == PHAuthorizationStatusRestricted)
+				onFail(@"PHAuthorizationStatusRestricted");
+		@}
+		
+		[Foreign(Language.ObjC)]
+		static void RequestPermissionsInternal(Action<string> onComplete, Action<string> onFail)
+		@{
+			PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
+			if (status == PHAuthorizationStatusNotDetermined)
+				[PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status){
+					if (status == PHAuthorizationStatusAuthorized)
+						onComplete(@"PHAuthorizationStatusAuthorized");
+					else
+						onFail(@"PHAuthorizationStatusDenied");
+				}];
+			else if (status == PHAuthorizationStatusAuthorized)
+				onComplete(@"PHAuthorizationStatusAuthorized");
+			else
+				dispatch_async(dispatch_get_main_queue(), ^{
+					[[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+				});
 		@}
 	}
 }

--- a/Tests/ManualTests/ManualTestingApp/Singles/CameraPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/CameraPage.ux
@@ -101,6 +101,34 @@
 				}
 			);
 		};
+		
+		exports.checkPermissions = function()
+		{
+			CameraRoll.checkPermissions().then(
+				function(res)
+				{
+					console.log("response: "+res)
+				}
+			).catch(
+				function(error){
+					console.log("error: "+error)
+				}
+			);
+		};
+
+		exports.requestPermissions = function()
+		{
+			CameraRoll.requestPermissions().then(
+				function(res)
+				{
+					console.log("response: "+res)
+				}
+			).catch(
+				function(error){
+					console.log("error: "+error)
+				}
+			);
+		};
 
 		exports.b64Test = function()
 		{
@@ -128,6 +156,8 @@
 			<StdButton Text="Take aspect corrected 100x100 picture via buffer" Clicked="{takeSmallPicture}"/>
 			<StdButton Text="Take cropped 320x320 picture" Clicked="{takeCroppedPicture}"/>
 			<StdButton Text="Get picture from cameraroll" Clicked="{selectImage}"/>
+			<StdButton Text="Check permission to access cameraroll" Clicked="{checkPermissions}"/>
+			<StdButton Text="Request permission to access cameraroll" Clicked="{requestPermissions}"/>
 			<WhileNotEmpty Items="{imagePath}">
 				<StdButton Text="Reload last picture via base64" Clicked="{b64Test}"/>
 			</WhileNotEmpty>


### PR DESCRIPTION
Sometimes automatically asking for access to photos may not be a good idea.
These new features allow the programmer to know the status and request access when the timing is appropriate.

More on that [here](https://uxplanet.org/getting-to-yes-best-practices-for-ios-permissions-dialogs-9d62892142cc).

### New
`checkPermissions()` - Checks if your app has access to the gallery.
`requestPermissions()` - Requests permission to access the gallery. In iOS, if the user has previously denied access this function will redirect them to your app settings in their iPhone / iPad.




This PR contains:
- [X] Changelog
- [X] Documentation
- [X] Tests