### PR TITLE
New camera features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Fuse.Deprecated.CameraView
 - This obsolete package has been removed. All functionality should be present in `Fuse.Controls.CameraView` instead.
 
+### Camera
+- New feature: `checkPermissions()` - Check if your app has access to the camera.
+- New feature: `requestPermissions()` - Request permission to access the camera. In iOS, if the user has previously denied access this function will redirect them to your app settings in their iPhone / iPad.
+
 # 1.9
 
 ## 1.9.0

--- a/Source/Fuse.Camera/Camera.uno
+++ b/Source/Fuse.Camera/Camera.uno
@@ -37,6 +37,8 @@ namespace Fuse.Camera
 			if(_instance != null)return;
 			Resource.SetGlobalKey(_instance = this, "FuseJS/Camera");
 			AddMember(new NativePromise<Image, Scripting.Object>("takePicture", TakePictureInterface, Image.Converter));
+			AddMember(new NativePromise<string, string>("checkPermissions", CheckUserPermissions, null));
+			AddMember(new NativePromise<string, string>("requestPermissions", RequestUserPermissions, null));
 		}
 
 		/**
@@ -85,6 +87,40 @@ namespace Fuse.Camera
 			else
 				p.Reject(new Exception("Camera unsupported on current platform"));
 
+			return p;
+		}
+
+		/**
+			@scriptmethod checkPermissions()
+
+			Checks if device has permissions to access the camera.
+
+			@return (Promise) a Promise that resolves if the user has permission
+		*/
+		static Future<string> CheckUserPermissions(object[] args)
+		{
+			var p = new Promise<string>();
+			if defined(Android)
+				AndroidCamera.CheckPermissions(p);
+			else if defined(iOS)
+				iOSCamera.CheckPermissions(p);
+			return p;
+		}
+
+		/**
+			@scriptmethod requestPermissions()
+
+			Requests acccess to the camera
+
+			@return (Promise) a Promise that resolves after the user has granted permissions
+		*/
+		static Future<string> RequestUserPermissions(object[] args) 
+		{
+			var p = new Promise<string>();
+			if defined(Android)
+				AndroidCamera.RequestPermissions(p);
+			else if defined(iOS)
+				iOSCamera.RequestPermissions(p);
 			return p;
 		}
 	}

--- a/Source/Fuse.Camera/iOS/iOSCamera.uno
+++ b/Source/Fuse.Camera/iOS/iOSCamera.uno
@@ -13,11 +13,56 @@ namespace Fuse.Camera
 			var cb = new ImagePromiseCallback(p);
 			TakePictureInternal(cb.Resolve, cb.Reject);
 		}
+		
+		internal static void CheckPermissions(Promise<string> p)
+		{
+			var cb = new PromiseCallback<string>(p);
+			CheckPermissionsInternal(cb.Resolve, cb.Reject);
+		}
+		
+		internal static void RequestPermissions(Promise<string> p)
+		{
+			var cb = new PromiseCallback<string>(p);
+			RequestPermissionsInternal(cb.Resolve, cb.Reject);
+		}
 
 		[Foreign(Language.ObjC)]
 		static void TakePictureInternal(Action<string> onComplete, Action<string> onFail)
 		@{
 			[[CameraHelper instance] takePictureWithCompletionHandler:onComplete onFail:onFail];
+		@}
+		
+		[Foreign(Language.ObjC)]
+		static void CheckPermissionsInternal(Action<string> onComplete, Action<string> onFail)
+		@{
+			AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+			if (status == AVAuthorizationStatusAuthorized)
+				onComplete(@"AVAuthorizationStatusAuthorized");
+			else if (status == AVAuthorizationStatusNotDetermined)
+				onFail(@"AVAuthorizationStatusNotDetermined");
+			else if (status == AVAuthorizationStatusDenied)
+				onFail(@"AVAuthorizationStatusDenied");
+			else if (status == AVAuthorizationStatusRestricted)
+				onFail(@"AVAuthorizationStatusRestricted");
+		@}
+		
+		[Foreign(Language.ObjC)]
+		static void RequestPermissionsInternal(Action<string> onComplete, Action<string> onFail)
+		@{
+			AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+			if (status == AVAuthorizationStatusNotDetermined)
+				[AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
+					if(granted)
+						onComplete(@"AVAuthorizationStatusAuthorized");
+					else
+						onFail(@"AVAuthorizationStatusDenied");
+				}];
+			else if (status == AVAuthorizationStatusAuthorized)
+				onComplete(@"AVAuthorizationStatusAuthorized");
+			else
+				dispatch_async(dispatch_get_main_queue(), ^{
+					[[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+				});
 		@}
 	}
 }

--- a/Tests/ManualTests/ManualTestingApp/Singles/CameraPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/CameraPage.ux
@@ -116,9 +116,9 @@
 			);
 		};
 
-    exports.checkPermissions = function()
+		exports.requestCameraPermissions = function()
 		{
-			CameraRoll.checkPermissions().then(
+			Camera.requestPermissions().then(
 				function(res)
 				{
 					console.log("response: "+res)
@@ -129,10 +129,10 @@
 				}
 			);
 		};
-
-		exports.requestCameraPermissions = function()
+		
+		exports.checkPermissions = function()
 		{
-			Camera.requestPermissions().then(
+			CameraRoll.checkPermissions().then(
 				function(res)
 				{
 					console.log("response: "+res)

--- a/Tests/ManualTests/ManualTestingApp/Singles/CameraPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/CameraPage.ux
@@ -101,6 +101,34 @@
 				}
 			);
 		};
+		
+		exports.checkCameraPermissions = function()
+		{
+			Camera.checkPermissions().then(
+				function(res)
+				{
+					console.log("response: "+res)
+				}
+			).catch(
+				function(error){
+					console.log("error: "+error)
+				}
+			);
+		};
+
+		exports.requestCameraPermissions = function()
+		{
+			Camera.requestPermissions().then(
+				function(res)
+				{
+					console.log("response: "+res)
+				}
+			).catch(
+				function(error){
+					console.log("error: "+error)
+				}
+			);
+		};
 
 		exports.b64Test = function()
 		{
@@ -128,6 +156,8 @@
 			<StdButton Text="Take aspect corrected 100x100 picture via buffer" Clicked="{takeSmallPicture}"/>
 			<StdButton Text="Take cropped 320x320 picture" Clicked="{takeCroppedPicture}"/>
 			<StdButton Text="Get picture from cameraroll" Clicked="{selectImage}"/>
+			<StdButton Text="Check permission to access the camera" Clicked="{checkCameraPermissions}"/>
+			<StdButton Text="Request permission to access the camera" Clicked="{requestCameraPermissions}"/>
 			<WhileNotEmpty Items="{imagePath}">
 				<StdButton Text="Reload last picture via base64" Clicked="{b64Test}"/>
 			</WhileNotEmpty>


### PR DESCRIPTION
Similar to #1209 

Sometimes automatically asking for access to the camera may not be a good idea.
These new features allow the programmer to know the status and request access when the timing is appropriate.

More on that [here](https://uxplanet.org/getting-to-yes-best-practices-for-ios-permissions-dialogs-9d62892142cc).

### New

`checkPermissions()` - Checks if your app has access to the camera.
`requestPermissions()` - Requests permission to access the camera. In iOS, if the user has previously denied access this function will redirect them to your app settings in their iPhone / iPad.

This PR contains:
- [X] Changelog
- [X] Documentation
- [X] Tests