### PR TITLE
Change version of play services of Maps

### DIFF
--- a/Source/Fuse.Maps/Android/MapView.uno
+++ b/Source/Fuse.Maps/Android/MapView.uno
@@ -14,7 +14,7 @@ namespace Fuse.Maps.Android
 		MOVE = 2
 	}
 
-	[Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-maps:9.2.0")]
+	[Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-maps:12.0.1")]
 	extern (Android) public class MapView : Fuse.Controls.Native.Android.LeafView, IMapView
 	{
 		public bool IsReady { get; private set; }


### PR DESCRIPTION
Change the version of play services of Fuse.Maps to **12.0.1** To work and compile with the last commit of Fuse.Firebase(https://github.com/fuse-compound/Fuse.Firebase)

SOLVE this problem: https://stackoverflow.com/questions/41408514/com-google-android-gms-common-internal-safe-parcel-safe-parcelable-not-found