### PR TITLE
Fuse.Triggers: ignore spuriously failing test

### DIFF
--- a/Source/Fuse.Triggers/Tests/Callback.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Callback.Test.uno
@@ -12,6 +12,7 @@ namespace Fuse.Test
 	public class CallbackTest : TestBase
 	{
 		[Test]
+		[Ignore("https://github.com/fuse-open/fuselibs/issues/1188")]
 		public void ArgsContainsSender()
 		{
 			var p = new UX.Callback.ArgsContainsSender();


### PR DESCRIPTION
This makes life with CI much more comfortable. This test has been randomly failing for a while, stalling otherwise good PRs.
