### PR TITLE
Fix build.sh error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,5 +13,4 @@ set -e
 cd "`dirname "$0"`"
 
 nuget install -ConfigFile Stuff/NuGet.config -OutputDirectory Stuff -ExcludeVersion Stuff/packages.config
-$clr Stuff/stuff.exe install Stuff
 $clr Stuff/uno.exe doctor $*


### PR DESCRIPTION
After the last .stuff file in the Stuff dir was removed the build script now exits with an "ERROR: No input files" output on my mac.

Removing the redundant stuff line fixes this.