### PR TITLE
Fix iOS DatePicker in WhileTrue bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.Controls.DatePicker
+- Fixed bug which caused dates not to be selectable if the control was inside a WhileTrue on iOS
+
 ### Fuse.Deprecated.CameraView
 - This obsolete package has been removed. All functionality should be present in `Fuse.Controls.CameraView` instead.
 

--- a/Source/Fuse.Controls.DatePicker/iOS/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/iOS/DatePicker.uno
@@ -27,8 +27,8 @@ namespace Fuse.Controls.Native.iOS
 			_host = host;
 
 			// The native control might reject values outside of the min/max range, so make sure we set min/max first
-			MinValue = _host.Value;
-			MaxValue = _host.Value;
+			MinValue = _host.MinValue;
+			MaxValue = _host.MaxValue;
 			Value = _host.Value;
 
 			_valueChangedEvent = UIControlEvent.AddValueChangedCallback(Handle, OnValueChanged);


### PR DESCRIPTION
The actual issue here was simple. The Min & Max were set to the Value,
which meant there were no valid dates so iOS greyed them out.

There is probably a secondary issue of why this issue didn't manifest without
the inclusion of the WhileTrue, but that is for a separate PR.

This fixes:
- https://github.com/fuse-open/fuselibs/issues/1218
- https://forums.fusetools.com/t/datepicker-wont-allow-date-change-when-inside-whiletrue-on-ios/7295

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
