### PR TITLE
Fix iOS not delivering local notif, if launched from statusbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.LocalNotifications
+- Fix bug on iOS where an app is launched (not restored) from a notification and the notification isn't delivered
+
 ### Fuse.Deprecated.CameraView
 - This obsolete package has been removed. All functionality should be present in `Fuse.Controls.CameraView` instead.
 

--- a/Source/Fuse.LocalNotifications/iOS/AppDelegateLocalNotify.mm
+++ b/Source/Fuse.LocalNotifications/iOS/AppDelegateLocalNotify.mm
@@ -12,6 +12,7 @@
 	  UIUserNotificationTypeBadge|
 	  UIUserNotificationTypeSound
 	  categories:nil]];
+	@{Fuse.LocalNotifications.iOSImpl.SendPendingFromLaunchOptions():Call()};
 }
 
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification

--- a/Source/Fuse.LocalNotifications/iOS/Impl.uno
+++ b/Source/Fuse.LocalNotifications/iOS/Impl.uno
@@ -11,10 +11,46 @@ using Uno.Compiler.ExportTargetInterop;
 namespace Fuse.LocalNotifications
 {
 	[Require("Entity", "Fuse.LocalNotifications.iOSImpl.OnReceivedLocalNotification(string)")]
+	[Require("Entity", "Fuse.LocalNotifications.iOSImpl.SendPendingFromLaunchOptions()")]
+	[Require("Entity", "Uno.Platform.iOS.Application.LaunchOptions")]
 	[Require("uContext.SourceFile.DidFinishLaunching", "[self initializeLocalNotifications:[notification object]];")]	
 	[Require("uContext.SourceFile.Declaration", "#include <iOS/AppDelegateLocalNotify.h>")]
     internal extern(iOS) static class iOSImpl
     {
+		public static void SendPendingFromLaunchOptions()
+		{
+			Fuse.LocalNotifications.iOSImpl.SendPendingFromLaunchOptions(Uno.Platform.iOS.Application.LaunchOptions);
+		}
+
+		[Foreign(Language.ObjC)]
+		static void SendPendingFromLaunchOptions(ObjC.Object lOpts)
+		@{
+			NSDictionary* launchOptions = (NSDictionary*)lOpts;
+			UILocalNotification* notification = [launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+			if (notification)
+			{
+				NSError* err = NULL;
+				NSMutableDictionary* userInfo;
+
+				if (notification.userInfo)
+					userInfo = [notification.userInfo mutableCopy];
+				else
+					userInfo = [NSMutableDictionary dictionary];
+
+				if (notification.alertAction)
+					[userInfo setObject:notification.alertAction forKey:@"title"];
+				if (notification.alertBody)
+					[userInfo setObject:notification.alertBody forKey:@"body"];
+
+				NSData* jsonData = [NSJSONSerialization dataWithJSONObject:userInfo options:0 error:&err];
+				if (jsonData)
+				{
+					NSString* nsJsonPayload = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+					@{Fuse.LocalNotifications.iOSImpl.OnReceivedLocalNotification(string):Call(nsJsonPayload)};
+				}
+			}
+		@}
+
         [Foreign(Language.ObjC)]
         internal static void Later(string title, string body, bool sound, string strPayload,
                                    int delaySeconds=0, int badgeNumber=0)


### PR DESCRIPTION
This fixes https://github.com/fuse-open/fuselibs/issues/1219

The issue was that, in the case where an app is started (rather than
just restored) by clicking on a notification in the status bar, the
notification is delivered via the iOS launch options and not the usual callback

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
