### PR TITLE
fix invalid json in local notif payload on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.LocalNotifications
+- Fix bug on android where the payload contain invalid json
+
 ### Fuse.Deprecated.CameraView
 - This obsolete package has been removed. All functionality should be present in `Fuse.Controls.CameraView` instead.
 

--- a/Source/Fuse.LocalNotifications/Android/Impl.uno
+++ b/Source/Fuse.LocalNotifications/Android/Impl.uno
@@ -68,7 +68,7 @@ namespace Fuse.LocalNotifications
                         String title = newIntent.getStringExtra("title");
                         String body = newIntent.getStringExtra("bbody");
                         String payload = newIntent.getStringExtra(@{ACTION});
-                        String result = "{ 'title': '" + title + "', 'body': '" + body + "', 'payload': '" + payload + "' }";
+						String result = com.fuse.LocalNotifications.LocalNotificationReceiver.MakePayloadString(title, body, payload);
                         @{NotificationRecieved(string):Call(result)};
                     }
                 },
@@ -128,7 +128,7 @@ namespace Fuse.LocalNotifications
 
             if (com.fuse.LocalNotifications.LocalNotificationReceiver.InForeground)
             {
-                String result = "{ 'title': '" + title + "', 'body': '" + body + "', 'payload': '" + payload + "' }";
+				String result = com.fuse.LocalNotifications.LocalNotificationReceiver.MakePayloadString(title, body, payload);
                 @{NotificationRecieved(string):Call(result)};
             } else {
                 Intent notificationIntent = new Intent(context, @(Activity.Package).@(Activity.Name).class);

--- a/Source/Fuse.LocalNotifications/Android/LocalNotificationReceiver.java
+++ b/Source/Fuse.LocalNotifications/Android/LocalNotificationReceiver.java
@@ -3,6 +3,7 @@ package com.fuse.LocalNotifications;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import org.json.JSONObject;
 
 public class LocalNotificationReceiver extends BroadcastReceiver {
     public static boolean InForeground = false;
@@ -12,4 +13,19 @@ public class LocalNotificationReceiver extends BroadcastReceiver {
     {
         com.foreign.Fuse.LocalNotifications.AndroidImpl.OnNotificationRecieved(context, intent);
     }
+
+	public static String MakePayloadString(String title, String body, String payload)
+	{
+		JSONObject jsonObj = new JSONObject();
+		try
+		{
+			jsonObj.put("title", (title == null ? "" : title));
+			jsonObj.put("body", (body == null ? "" : body));
+			jsonObj.put("payload", (payload == null ? "" : payload));
+		}
+		catch (Exception e)
+		{
+		}
+		return jsonObj.toString();
+	}
 }


### PR DESCRIPTION
Replace the old hacky way of making the result string with use of
JSONObject.

I'm not stoked with putting the helper function in
LocalNotificationReceiver however it saves adding extra java files to
the build for now when we have something that already works.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
