### PR TITLE
Updated Push Notifications

### DIFF
--- a/Source/Fuse.PushNotifications/Android/Impl.uno
+++ b/Source/Fuse.PushNotifications/Android/Impl.uno
@@ -21,6 +21,7 @@ namespace Fuse.PushNotifications
 					"android.media.RingtoneManager",
 					"android.net.Uri",
 					"android.os.Bundle",
+					"android.graphics.Color",
 					"android.support.v4.app.NotificationCompat",
 					"com.fuse.PushNotifications.PushNotificationReceiver",
 					"com.fuse.PushNotifications.BigPictureStyleHttp",
@@ -265,7 +266,17 @@ namespace Fuse.PushNotifications
 			if (cls == String.class)
 			{
 				String title = (String)alertObj;
-				@{SpitOutNotification(Java.Object,string,string,string,string,string,string,string,Java.Object):Call(listener,
+				@{SpitOutNotification(Java.Object,
+					string,string,
+					string,string,string,string,
+					string,string,
+					string,string,string,
+					string,string,string,
+					string,string,string,
+					string,string,string,
+					string,string,
+					string,string,
+					Java.Object):Call(listener,
 						title,
 						"",
 						json.optString("bigTitle"),
@@ -273,6 +284,23 @@ namespace Fuse.PushNotifications
 						json.optString("notificationStyle"),
 						json.optString("featuredImage"),
 						json.optString("sound"),
+						json.optString("color"),
+						json.optString("notificationPriority"),
+						json.optString("notificationCategory"),
+						json.optString("notificationLockscreenVisibility"),
+						json.optString("notificationChannelId"),
+						json.optString("notificationChannelName"),
+						json.optString("notificationChannelDescription"),
+						json.optString("notificationChannelImportance"),
+						json.optString("notificationChannelLockscreenVisibility"),
+						json.optString("notificationChannelLightColor"),
+						json.optString("notificationChannelIsVibrationOn"),
+						json.optString("notificationChannelIsSoundOn"),
+						json.optString("notificationChannelIsShowBadgeOn"),
+						json.optString("notificationChannelGroupId"),
+						json.optString("notificationChannelGroupName"),
+						json.optString("notificationBadgeNumber"),
+						json.optString("notificationBadgeIconType"),
 						bundle)};
 			}
 			else
@@ -280,7 +308,17 @@ namespace Fuse.PushNotifications
 				JSONObject alert = (JSONObject)alertObj;
 				if (alertObj!=null)
 				{
-					@{SpitOutNotification(Java.Object,string,string,string,string,string,string,string,Java.Object):Call(listener,
+					@{SpitOutNotification(Java.Object,
+						string,string,
+						string,string,string,string,
+						string,string,
+						string,string,string,
+						string,string,string,
+						string,string,string,
+						string,string,string,
+						string,string,
+						string,string,
+						Java.Object):Call(listener,
 						alert.optString("title"),
 						alert.optString("body"),
 						alert.optString("bigTitle"),
@@ -288,13 +326,40 @@ namespace Fuse.PushNotifications
 						alert.optString("notificationStyle"),
 						alert.optString("featuredImage"),
 						alert.optString("sound"),
+						alert.optString("color"),
+						alert.optString("notificationPriority"),
+						alert.optString("notificationCategory"),
+						alert.optString("notificationLockscreenVisibility"),
+						alert.optString("notificationChannelId"),
+						alert.optString("notificationChannelName"),
+						alert.optString("notificationChannelDescription"),
+						alert.optString("notificationChannelImportance"),
+						alert.optString("notificationChannelLockscreenVisibility"),
+						alert.optString("notificationChannelLightColor"),
+						alert.optString("notificationChannelIsVibrationOn"),
+						alert.optString("notificationChannelIsSoundOn"),
+						alert.optString("notificationChannelIsShowBadgeOn"),
+						alert.optString("notificationChannelGroupId"),
+						alert.optString("notificationChannelGroupName"),
+						alert.optString("notificationBadgeNumber"),
+						alert.optString("notificationBadgeIconType"),
 						bundle)};
 				}
 			}
 		@}
 
 		[Foreign(Language.Java)]
-		static void SpitOutNotification(Java.Object _listener, string title, string body, string bigTitle, string bigBody, string notificationStyle, string featuredImage, string sound, Java.Object _payload)
+		static void SpitOutNotification(Java.Object _listener, 
+			string title, string body, 
+			string bigTitle, string bigBody, string notificationStyle, string featuredImage, 
+			string sound, string color, 
+			string notificationPriority, string notificationCategory, string notificationLockscreenVisibility,
+			string notificationChannelId, string notificationChannelName, string notificationChannelDescription, 
+			string notificationChannelImportance, string notificationChannelLockscreenVisibility, string notificationChannelLightColor,
+			string notificationChannelIsVibrationOn, string notificationChannelIsSoundOn, string notificationChannelIsShowBadgeOn,
+			string notificationChannelGroupId, string notificationChannelGroupName, 
+			string notificationBadgeNumber, string notificationBadgeIconType,
+			Java.Object _payload)
 		@{
 			int id = PushNotificationReceiver.nextID();
 			Context context = (Context)_listener;
@@ -306,17 +371,281 @@ namespace Fuse.PushNotifications
 			android.app.PendingIntent pendingIntent = android.app.PendingIntent.getActivity(context, id, intent, android.app.PendingIntent.FLAG_UPDATE_CURRENT);
 			android.app.NotificationManager notificationManager = (android.app.NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-			NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
-				.setSmallIcon(@(Activity.Package).R.mipmap.notif)
-				.setContentTitle(title)
-				.setContentText(body)
+			/// Setup Default notification channel properties to fallback on
+			/// NB: Once a channel is created, you can't change the importance, etc.
+			// Notification Channel id - unique identifier that you could use to get the channel properties
+			String channelId = "@(Project.Android.Notification.DefaultChannelId)";
+			channelId = (channelId != "") ? channelId : "default_channel";
+			/* Notification Channel name - appears in the App notification settings, under "Categories" or a group name 
+				- https://developer.android.com/training/notify-user/channels */
+			String channelName = "@(Project.Android.Notification.DefaultChannelName)";
+			channelName = (channelName != "") ? channelName : "App";
+			// Notification Channel description - appears under channel name in the App settings
+			String channelDescription = "@(Project.Android.Notification.DefaultChannelDescription)";
+			channelDescription = (channelDescription != "") ? channelDescription : "";
+			String channelImportanceIn = "@(Project.Android.Notification.DefaultChannelImportance)";
+			channelImportanceIn = (channelImportanceIn != "") ? channelImportanceIn : "";
+
+			/* Notification Channel overrides from notification payload
+				Minimum: each notification must define a Channel Id and Channel Name, else will be part of default notification channel
+			*/
+			if (
+				(notificationChannelId!=null && !notificationChannelId.isEmpty()) &&
+				(notificationChannelName!=null && !notificationChannelName.isEmpty())
+			) { 
+				channelId = notificationChannelId;
+				channelName = notificationChannelName;
+			}
+			if (notificationChannelDescription!=null && !notificationChannelDescription.isEmpty()) { channelDescription = notificationChannelDescription; }
+			if (notificationChannelImportance!=null && !notificationChannelImportance.isEmpty()) { channelImportanceIn = notificationChannelImportance; }
+
+			// Notification Channel - (Categories) since Oreo, is mandatory. Allows push to work on devices above API 25.
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+
+				// Notification Channel Importance - https://developer.android.com/training/notify-user/channels#importance
+				int channelImportance = android.app.NotificationManager.IMPORTANCE_DEFAULT;
+				switch(channelImportanceIn.toLowerCase()) {
+					case "urgent": channelImportance = android.app.NotificationManager.IMPORTANCE_HIGH; break;
+					case "high": channelImportance = android.app.NotificationManager.IMPORTANCE_DEFAULT; break;
+					case "medium": channelImportance = android.app.NotificationManager.IMPORTANCE_LOW; break;
+					case "low": channelImportance = android.app.NotificationManager.IMPORTANCE_MIN; break;
+					case "none": channelImportance = android.app.NotificationManager.IMPORTANCE_NONE; break;
+				}
+
+				android.app.NotificationChannel channel = new android.app.NotificationChannel(
+					channelId,
+					channelName,
+					channelImportance);
+				channel.setDescription(channelDescription);
+
+				/* Notification Channel Light Color - https://developer.android.com/training/notify-user/channels#CreateChannel
+					NB: A device supports this feature if you can find the option here for all apps:
+					Settings > Apps & notifications > Notifications > Blink light
+				*/
+				#if @(Project.Android.Notification.DefaultChannelLightColor:IsSet)
+					channel.enableLights(true);
+					channel.setLightColor(Color.parseColor("@(Project.Android.Notification.DefaultChannelLightColor)"));
+				#endif
+				// Allow for notificationChannelLightColor to be overridden from notification payload
+				if (notificationChannelLightColor!=null && !notificationChannelLightColor.isEmpty()) {
+					channel.enableLights(true);
+					channel.setLightColor(Color.parseColor(notificationChannelLightColor));
+				}
+
+				/* Notification Channel Vibration On
+					default vibration pattern: {0, 250, 250, 250}
+					- https://android.googlesource.com/platform/frameworks/base/+/master/services/core/java/com/android/server/notification/NotificationManagerService.java
+				*/
+				long[] DEFAULT_VIBRATE_PATTERN = {0, 250, 250, 250};
+				#if @(Project.Android.Notification.NotificationChannelIsVibrationOn:IsSet)
+					if (Boolean.parseBoolean("@(Project.Android.Notification.NotificationChannelIsVibrationOn)")) {
+						channel.enableVibration(true);
+						channel.setVibrationPattern(DEFAULT_VIBRATE_PATTERN);
+					}
+				#endif
+				// Allow for notificationChannelIsVibrationOn to be overridden from notification payload
+				if (notificationChannelIsVibrationOn!=null && !notificationChannelIsVibrationOn.isEmpty()
+					&& Boolean.parseBoolean(notificationChannelIsVibrationOn)) {
+					channel.enableVibration(true);
+					channel.setVibrationPattern(DEFAULT_VIBRATE_PATTERN);
+				}
+
+				// Notification Channel Sound On 
+				#if @(Project.Android.Notification.NotificationChannelIsSoundOn:IsSet)
+					if (Boolean.parseBoolean("@(Project.Android.Notification.NotificationChannelIsSoundOn)")) {
+						Uri defaultSoundUri = android.media.RingtoneManager.getDefaultUri(android.media.RingtoneManager.TYPE_NOTIFICATION);
+						android.media.AudioAttributes att = new android.media.AudioAttributes.Builder()
+							.setUsage(android.media.AudioAttributes.USAGE_NOTIFICATION)
+							.setContentType(android.media.AudioAttributes.CONTENT_TYPE_UNKNOWN)
+							.build();
+						if (notificationCategory.toLowerCase() == "alarm" || notificationCategory.toLowerCase() == "reminder") {
+							defaultSoundUri = android.media.RingtoneManager.getDefaultUri(android.media.RingtoneManager.TYPE_ALARM);
+							att = new android.media.AudioAttributes.Builder()
+								.setUsage(android.media.AudioAttributes.USAGE_ALARM)
+								.setContentType(android.media.AudioAttributes.CONTENT_TYPE_UNKNOWN)
+								.build();
+						}
+						channel.setSound(defaultSoundUri, att);
+					}
+				#endif
+				// Allow for notificationChannelIsSoundOn to be overridden from notification payload
+				if (notificationChannelIsSoundOn!=null && !notificationChannelIsSoundOn.isEmpty() 
+					&& Boolean.parseBoolean(notificationChannelIsSoundOn)) {
+					Uri defaultSoundUri = android.media.RingtoneManager.getDefaultUri(android.media.RingtoneManager.TYPE_NOTIFICATION);
+					android.media.AudioAttributes att = new android.media.AudioAttributes.Builder()
+						.setUsage(android.media.AudioAttributes.USAGE_NOTIFICATION)
+						.setContentType(android.media.AudioAttributes.CONTENT_TYPE_UNKNOWN)
+						.build();
+					if (notificationCategory.toLowerCase() == "alarm" || notificationCategory.toLowerCase() == "reminder") {
+						defaultSoundUri = android.media.RingtoneManager.getDefaultUri(android.media.RingtoneManager.TYPE_ALARM);
+						att = new android.media.AudioAttributes.Builder()
+							.setUsage(android.media.AudioAttributes.USAGE_ALARM)
+							.setContentType(android.media.AudioAttributes.CONTENT_TYPE_UNKNOWN)
+							.build();
+					}
+					channel.setSound(defaultSoundUri, att);
+				}
+				
+				// Notification Channel Lock Screen Visibility - same as notification lock screen visibility which is deprecated from Oreo+ (see below)
+				String notificationChannelLockscreenVisibilityIn = "";
+				#if @(Project.Android.Notification.NotificationChannelLockscreenVisibility:IsSet)
+					notificationChannelLockscreenVisibilityIn = "@(Project.Android.Notification.NotificationChannelLockscreenVisibility)";
+				#endif
+				if (notificationChannelLockscreenVisibility!=null && !notificationChannelLockscreenVisibility.isEmpty())
+					notificationChannelLockscreenVisibilityIn = notificationChannelLockscreenVisibility;
+				switch(notificationChannelLockscreenVisibilityIn.toLowerCase()) {
+					case "public": channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC); break;
+					case "secret": channel.setLockscreenVisibility(Notification.VISIBILITY_SECRET); break;
+					case "private": channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE); break;
+				}
+
+				/* Notification Channel Show Badge
+					NB: A device supports this feature if you can find the option here for all apps:
+					Settings > Apps & notifications > Notifications > Allow notification dots
+				*/
+				#if @(Project.Android.Notification.NotificationChannelIsShowBadgeOn:IsSet)
+					channel.setShowBadge(Boolean.parseBoolean("@(Project.Android.Notification.NotificationChannelIsShowBadgeOn)"));
+				#endif
+				// Allow for notificationChannelIsShowBadgeOn to be overridden from notification payload
+				if (notificationChannelIsShowBadgeOn!=null && !notificationChannelIsShowBadgeOn.isEmpty()) {
+					channel.setShowBadge(Boolean.parseBoolean(notificationChannelIsShowBadgeOn));
+				}
+
+				///Set up default notification channel group
+				// Notification Channel Group id - unique identifier that you could use to set/get the channel group
+				String channelGroupId = "@(Project.Android.Notification.DefaultChannelGroupId)";
+				channelGroupId = (channelGroupId != "") ? channelGroupId : "default_group";
+				/* Notification Channel Group name - appears in the App notification settings, replaces "Categories"
+				e.g. Personal e.g. Business e.g. Social
+						- https://developer.android.com/training/notify-user/channels#CreateChannelGroup */
+				String channelGroupName = "@(Project.Android.Notification.DefaultChannelGroupName)";
+				channelGroupName = (channelGroupName != "") ? channelGroupName : "Categories";
+				// Notification Channel Group overrides from notification payload
+				if (
+					(notificationChannelGroupId!=null && !notificationChannelGroupId.isEmpty()) &&
+					(notificationChannelGroupName!=null && !notificationChannelGroupName.isEmpty())
+				) { 
+					channelGroupId = notificationChannelGroupId;
+					channelGroupName = notificationChannelGroupName;
+				}
+				notificationManager.createNotificationChannelGroup(new android.app.NotificationChannelGroup(channelGroupId, channelGroupName));
+
+				channel.setGroup(channelGroupId);
+				notificationManager.createNotificationChannel(channel);
+			}
+
+			NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, channelId)
+				.setSmallIcon(@(Activity.Package).R.mipmap.notif) // required
+				.setContentText(body) // required
 				.setAutoCancel(true)
 				.setContentIntent(pendingIntent);
 
-			if (sound=="default")
-			{
-				Uri defaultSoundUri= RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-				notificationBuilder.setSound(defaultSoundUri);
+			// For API < Oreo API 26
+			if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) { 
+				//Notification Sound 
+				if (sound=="default")
+				{
+					if (android.os.Build.VERSION.SDK_INT >= 21) { //Lollipop
+						//see below by notification
+					} else { //less than Lollipop
+						Uri defaultSoundUri= RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+						notificationBuilder.setSound(defaultSoundUri, android.media.AudioManager.STREAM_NOTIFICATION);
+					}
+				}
+			}
+
+			// Notification Badge Number (Android 8, Oreo, API 26)
+			// - https://developer.android.com/training/notify-user/badges
+			if (notificationBadgeNumber!=null && !notificationBadgeNumber.isEmpty()) {
+				notificationBuilder.setNumber(Integer.parseInt(notificationBadgeNumber));
+			}
+
+			// Notification Badge Icon Type
+			// - https://developer.android.com/training/notify-user/badges
+			switch(notificationBadgeIconType.toLowerCase()) {
+				case "none": notificationBuilder.setBadgeIconType(NotificationCompat.BADGE_ICON_NONE); break;
+				case "small": notificationBuilder.setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL); break;
+				case "large": notificationBuilder.setBadgeIconType(NotificationCompat.BADGE_ICON_LARGE); break;
+			}
+
+			/* Notification Lock Screen Visibility - https://developer.android.com/training/notify-user/build-notification#lockscreenNotification
+				public: shows the notification's full content.
+				secret: doesn't show any part of this notification on the lock screen.
+				private: shows basic information, such as the notification's icon and the content title, but hides the notification's full content.
+			*/
+			String notificationLockscreenVisibilityIn = "";
+			#if @(Project.Android.Notification.NotificationLockscreenVisibility:IsSet)
+				notificationLockscreenVisibilityIn = "@(Project.Android.Notification.NotificationLockscreenVisibility)";
+			#endif
+			if (notificationLockscreenVisibility!=null && !notificationLockscreenVisibility.isEmpty())
+				notificationLockscreenVisibilityIn = notificationLockscreenVisibility;
+			switch(notificationLockscreenVisibilityIn.toLowerCase()) {
+				case "public": notificationBuilder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC); break;
+				case "secret": notificationBuilder.setVisibility(NotificationCompat.VISIBILITY_SECRET); break;
+				case "private": notificationBuilder.setVisibility(NotificationCompat.VISIBILITY_PRIVATE); break;
+			}
+			
+			/* Notification Category - https://developer.android.com/training/notify-user/build-notification#system-category
+				Android uses a some pre-defined system-wide categories to determine whether to disturb the user with 
+				a given notification when the user has enabled Do Not Disturb mode.
+			*/
+			switch(notificationCategory.toLowerCase()) {
+				// Important in Do Not Disturb mode - https://developer.android.com/guide/topics/ui/notifiers/notifications#dnd-mode
+				case "alarm": notificationBuilder.setCategory(NotificationCompat.CATEGORY_ALARM); break;
+				case "reminder": notificationBuilder.setCategory(NotificationCompat.CATEGORY_REMINDER); break;
+				case "event": notificationBuilder.setCategory(NotificationCompat.CATEGORY_EVENT); break;
+				case "call": notificationBuilder.setCategory(NotificationCompat.CATEGORY_CALL); break;
+				case "message": notificationBuilder.setCategory(NotificationCompat.CATEGORY_MESSAGE); break;
+				// Other categories (Updated Sep 2018) - https://developer.android.com/reference/android/support/v4/app/NotificationCompat
+				case "email": notificationBuilder.setCategory(NotificationCompat.CATEGORY_EMAIL); break;
+				case "promo": notificationBuilder.setCategory(NotificationCompat.CATEGORY_PROMO); break;
+				case "recommendation": notificationBuilder.setCategory(NotificationCompat.CATEGORY_RECOMMENDATION); break;
+				case "social": notificationBuilder.setCategory(NotificationCompat.CATEGORY_SOCIAL); break;
+				// System related categories
+				case "error": notificationBuilder.setCategory(NotificationCompat.CATEGORY_ERROR); break;
+				case "progress": notificationBuilder.setCategory(NotificationCompat.CATEGORY_PROGRESS); break;
+				case "service": notificationBuilder.setCategory(NotificationCompat.CATEGORY_SERVICE); break;
+				case "status": notificationBuilder.setCategory(NotificationCompat.CATEGORY_STATUS); break;
+				case "system": notificationBuilder.setCategory(NotificationCompat.CATEGORY_SYSTEM); break;
+				case "transport": notificationBuilder.setCategory(NotificationCompat.CATEGORY_TRANSPORT); break;
+			}
+
+			// Notification Priority - The priority determines how intrusive the notification should be on Android 7.1 (Nougat - API 25) and lower
+			switch(notificationPriority.toLowerCase()) {
+				case "high": notificationBuilder.setPriority(NotificationCompat.PRIORITY_HIGH); break;
+				case "low": notificationBuilder.setPriority(NotificationCompat.PRIORITY_LOW); break;
+				case "max": notificationBuilder.setPriority(NotificationCompat.PRIORITY_MAX); break;
+				case "min": notificationBuilder.setPriority(NotificationCompat.PRIORITY_MIN); break;
+				default: notificationBuilder.setPriority(NotificationCompat.PRIORITY_DEFAULT); break;
+			}
+
+			/* 
+				Notification Title - From Nougat (API 24), the app name is included in notification,
+				so this allows you to hide your title when using it for your app name
+				Example value: 24 
+			*/
+			if (title!=null && !title.isEmpty()) {
+				String noTitleStyleMinAPIVersion = "@(Project.Android.Notification.NoTitleStyleMinAPIVersion)";
+				if (noTitleStyleMinAPIVersion != "" && (android.os.Build.VERSION.SDK_INT >= Integer.parseInt(noTitleStyleMinAPIVersion)) ) {
+					// Don't set title - Oreo+ will remove it from the UI
+				} else {
+					notificationBuilder.setContentTitle(title);
+				}
+			}
+
+			/*
+				Notification Color - Add color to your icon and from Oreo+ it adds the color to your app name as well
+				 - https://developer.android.com/guide/topics/ui/notifiers/notifications
+				parseColor() format #RRGGBB or #AARRGGBB 
+				 - https://developer.android.com/reference/android/graphics/Color#parseColor(java.lang.String)
+				Example value: #8811ff
+			*/
+			#if @(Project.Android.NotificationIcon.Color:IsSet)
+				notificationBuilder.setColor(Color.parseColor("@(Project.Android.NotificationIcon.Color)"));
+			#endif
+			// Allow for color to be overridden from notification payload
+			if (color!=null && !color.isEmpty()) {
+				notificationBuilder.setColor(Color.parseColor(color));
 			}
 
 
@@ -385,8 +714,19 @@ namespace Fuse.PushNotifications
 			}
 
 			Notification n = notificationBuilder.build();
-			if (sound!="")
+			if (sound!="" && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) { //< Oreo API 26
+				if(android.os.Build.VERSION.SDK_INT >= 21) { //Lollipop
+					Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+					n.sound = defaultSoundUri;
+					n.category = Notification.CATEGORY_ALARM;
+					
+					android.media.AudioAttributes.Builder attrs = new android.media.AudioAttributes.Builder();
+					attrs.setContentType(android.media.AudioAttributes.CONTENT_TYPE_SONIFICATION);
+					attrs.setUsage(android.media.AudioAttributes.USAGE_ALARM);
+					n.audioAttributes = attrs.build();
+				}
 				n.defaults |= Notification.DEFAULT_SOUND;
+			}
 			n.defaults |= Notification.DEFAULT_LIGHTS;
 			n.defaults |= Notification.DEFAULT_VIBRATE;
 			notificationManager.notify(id, n);

--- a/Source/Fuse.PushNotifications/Common.uno
+++ b/Source/Fuse.PushNotifications/Common.uno
@@ -150,5 +150,13 @@ namespace Fuse.PushNotifications
 		}
 
 		public extern(!iOS) static void Register() { }
+
+		public extern(iOS) static bool IsRegisteredForRemoteNotifications()
+		{
+			return iOSImpl.IsRegisteredForRemoteNotifications();
+		}
+
+		public extern(Android) static bool IsRegisteredForRemoteNotifications() { return true; }
+		public extern(!iOS && !Android) static bool IsRegisteredForRemoteNotifications() { return true; }
 	}
 }

--- a/Source/Fuse.PushNotifications/Docs/Guide.md
+++ b/Source/Fuse.PushNotifications/Docs/Guide.md
@@ -136,3 +136,232 @@ Google and Apple has different limits on the size of push notifications.
 - Google limits to 4096 bytes
 - Apple limits to 2048 bytes on iOS 8 and up but only 256 bytes on all earlier versions
 
+
+
+
+## Additional Android Push Notification Features
+
+Since Android 8+ (Oreo or API 26), it is mandatory to define and assign a channel to every notification.
+
+We have defined a default channel (named "App") to be assigned to notifications if they aren't already assigned a channel, so you don't need to define one but if you do want to customise it, read on.
+
+NB! Once a channel is created, you CANNOT change its properties later.
+
+Apart from the Notification Channel feature discussed above, here is a list of the other android features implemented thus far:
+
+- Notification Sound
+- Notification Color
+- Notification Priority
+- Notification Category
+- Notification Lockscreen Visibility
+
+Android 8+
+- Notification Channel
+- Nofitication Channel Group
+- Notification Channel Importance
+- Notification Channel Lockscreen Visibility
+- Notification Channel Light Color
+- Notification Channel Sound
+- Notification Channel Vibration
+- Notification Channel Show Badge
+- Notification Badge Number
+- Notification Badge Icon Type
+
+
+We'll show you how to implement them here in fuse but read more about each feature [here](https://developer.android.com/guide/topics/ui/notifiers/notifications).
+
+
+#### Notification Sound - Value - default
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'sound': 'default'
+        }
+    },
+
+
+#### Notification Color - Values - #RRGGBB | #AARRGGBB
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'color': '#8811FF'
+        }
+    },
+
+
+#### Notification Priority - Values - high | low | max | min
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationPriority': 'high'
+        }
+    },
+
+
+#### Notification Category - Values - alarm | reminder | event | call | message | email | promo | recommendation | social | error | progress | service | status | system | transport
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationCategory': 'social'
+        }
+    },
+
+
+#### Notification Lockscreen Visibility - Values - public | secret | private
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationLockscreenVisibility': 'secret'
+        }
+    },
+
+
+
+#### Notification Channel
+
+Notification Channel and a Notification Channel Group:
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelGroupId': 'sports',
+            'notificationChannelGroupName': 'Sports',
+            'notificationChannelId': 'sports_football_highlights',
+            'notificationChannelName': 'Football Highlights',
+            'notificationChannelDescription': 'Video commentary once a week'
+        }
+    },
+
+Notification Channel Importance - Values - urgent | high | medium | low | none
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelGroupId': 'sports',
+            'notificationChannelGroupName': 'Sports',
+            'notificationChannelId': 'sports_basketball_highlights',
+            'notificationChannelName': 'Basketball Highlights',
+            'notificationChannelDescription': 'Video commentary once a week',
+            'notificationChannelImportance': 'urgent',
+
+        }
+    },
+
+
+Notification Channel Lockscreen Visibility - Values - public | secret | private
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelLockscreenVisibility': 'private'
+        }
+    },
+
+
+Notification Channel Light Color - Values - #RRGGBB
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelLightColor': '#1188FF'
+        }
+    },
+
+
+Notification Channel Sound - Values - true | false
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelIsSoundOn': 'true'
+        }
+    },
+
+
+Notification Channel Vibration - Values - true | false
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelIsVibrationOn': 'true'
+        }
+    },
+
+
+Notification Channel Show Badge - Values - true | false
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationChannelIsShowBadgeOn': 'true'
+        }
+    },
+
+
+#### Notification Badge
+
+Notification Channel Badge Number
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationBadgeNumber': '23'
+        }
+    },
+
+
+Notification Channel Badge Icon Type - Values - none | small | large
+
+    'notification': {
+        alert: {
+            'title': 'Well would ya look at that!',
+            'body': 'Hello from the server',
+            'notificationBadgeIconType': 'small'
+        }
+    },
+
+
+
+#### Notification Uno Project Configurations
+
+The following notification settings can be set via the `.unoproj` settings:
+
+    "Android": {
+        ...
+        "Notification": {
+            "DefaultChannelGroupId": "default_group",
+            "DefaultChannelGroupName": "Categories",
+            "DefaultChannelId": "default_channel",
+            "DefaultChannelName": "App",
+            "DefaultChannelDescription": "",
+            "DefaultChannelImportance": "high",
+            "DefaultChannelLightColor": "#FF2C37",
+            "NotificationChannelLockscreenVisibility": "secret",
+            "NotificationChannelIsSoundOn": true,
+            "NotificationChannelIsShowBadgeOn": true,
+            "NotificationChannelIsVibrationOn": true
+        }
+        ...
+    },
+
+
+Note: notification payload settings will always override the notification settings from `.unoproj`.
+NB! Once a channel is created, you CANNOT change its properties later.

--- a/Source/Fuse.PushNotifications/JS.uno
+++ b/Source/Fuse.PushNotifications/JS.uno
@@ -64,6 +64,7 @@ namespace Fuse.PushNotifications
 			AddMember(new NativeFunction("clearBadgeNumber", ClearBadgeNumber));
 			AddMember(new NativeFunction("clearAllNotifications", ClearAllNotifications));
 			AddMember(new NativeFunction("register", Register));
+			AddMember(new NativeFunction("isRegisteredForRemoteNotifications", IsRegisteredForRemoteNotifications));
 
 			Fuse.PushNotifications.PushNotify.ReceivedNotification += OnReceivedNotification;
 			Fuse.PushNotifications.PushNotify.RegistrationSucceeded += OnRegistrationSucceeded;
@@ -142,6 +143,21 @@ namespace Fuse.PushNotifications
 			}
 			Fuse.PushNotifications.PushNotify.Register();
 			return null;
+		}
+
+		/**
+			@scriptmethod isRegisteredForRemoteNotifications
+
+			Gets whether or not the user has enabled remote notifications
+		*/
+		public object IsRegisteredForRemoteNotifications(Context context, object[] args)
+		{
+			if (args.Length != 0)
+			{
+				Fuse.Diagnostics.UserError( "Push.isRegisteredForRemoteNotifications takes no arguments", this);
+				return null;
+			}
+			return Fuse.PushNotifications.PushNotify.IsRegisteredForRemoteNotifications();
 		}
 	}
 }

--- a/Source/Fuse.PushNotifications/iOS/Impl.uno
+++ b/Source/Fuse.PushNotifications/iOS/Impl.uno
@@ -11,6 +11,8 @@ namespace Fuse.PushNotifications
 	[Require("Entity", "Fuse.PushNotifications.iOSImpl.OnReceivedNotification(string,bool)")]
 	[Require("uContext.SourceFile.DidFinishLaunching", "[self application:[notification object] initializePushNotifications:[notification userInfo]];")]
 	[Require("uContext.SourceFile.Declaration", "#include <iOS/AppDelegatePushNotify.h>")]
+	[Require("Xcode.Framework", "UserNotifications.framework")]
+	[Require("Source.Include", "UserNotifications/UserNotifications.h")]
 	extern(iOS)
 	internal class iOSImpl
 	{
@@ -94,26 +96,50 @@ namespace Fuse.PushNotifications
 			DelayedRegToken = "";
 			Lifecycle.EnteringForeground -= DispatchDelayedRegToken;
 		}
+		
+		[Foreign(Language.ObjC)]
+		internal static bool SYSTEM_VERSION_LESS_THAN(string v)
+		@{
+			return ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending);  
+		@}
 
 		[Foreign(Language.ObjC)]
 		internal static void RegisterForPushNotifications()
 		@{
 			UIApplication* application = [UIApplication sharedApplication];
-			if ([application respondsToSelector:@selector(registerUserNotificationSettings:)]) {
-				// use registerUserNotificationSettings
-				dispatch_async(dispatch_get_main_queue(), ^{
-					[application registerUserNotificationSettings: [UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeSound  | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge)  categories:nil]];
-					[application registerForRemoteNotifications];
-				});
-			} else {
-				// use registerForRemoteNotificationTypes:
+	    if( @{SYSTEM_VERSION_LESS_THAN(string):Call(@"10.0")} ) {  
+	    	// Use registerForRemoteNotificationTypes for iOS < 10
 				dispatch_async(dispatch_get_main_queue(), ^{
 					[application registerForRemoteNotificationTypes:
 					 UIRemoteNotificationTypeBadge |
 					 UIRemoteNotificationTypeSound |
 					 UIRemoteNotificationTypeAlert];
 				});
-			}
+    	} else {
+    		// Use registerForRemoteNotifications for iOS >= 10
+    		dispatch_async(dispatch_get_main_queue(), ^{
+					/* 
+						Explicitly ask for permission else notifications are silent
+						https://developer.apple.com/documentation/uikit/uiapplication/1623078-registerforremotenotifications?language=objc
+					*/
+					UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+					[center requestAuthorizationWithOptions:
+					         (UNAuthorizationOptionAlert + 
+					          UNAuthorizationOptionSound +
+					          UNAuthorizationOptionBadge)
+					   completionHandler:^(BOOL granted, NSError * _Nullable error) {
+					 	 /* Continue to register users token, so that if they turn it on
+					   		in their general settings later, it will be "on" in your server side too */
+						[application registerForRemoteNotifications];	
+					}];
+				});
+    	}
+		@}
+
+		[Foreign(Language.ObjC)]
+		internal static bool IsRegisteredForRemoteNotifications()
+		@{
+			return [[UIApplication sharedApplication] isRegisteredForRemoteNotifications];
 		@}
 	}
 }


### PR DESCRIPTION
27 Sep - iOS & Android: Push Notification Fixes + Features
Android
Fixes

- Added default Notification Channel, so won't have to compile for API 25 to get push notifications working.
- Can configure the default channel name via unoconfig
Features

- Added setting of icon color / app name
- Can set color via unoconfig & notification payload
- Added the ability to hide the title via unoconfig

iOS
Fixes

- Explicitly ask for permission so notifications won't be silent
- Updated version check

Feature

- Added function to get whether or not the user has push notifications turned on or off

28 Sep - Added Push Notification Features

Android
- Notification Category
- Notification Color
- Notification Lockscreen Visibility
- Notification Priority
- Notification Sound
- No Title Style

Android 8+
- Notification Channel
- Nofitication Channel Group
- Notification Channel Importance
- Notification Channel Lockscreen Visibility
- Notification Channel Light Color
- Notification Channel Sound
- Notification Channel Show Badge
- Notification Channel Vibration
- Notification Badge Number
- Notification Badge Icon Type

1 Oct - Added documentation for how to implement the new android push notification features in fuse


This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
