### PR TITLE
Fuse.*Notifications: clarify ambiguous symbol

### DIFF
--- a/Source/Fuse.LocalNotifications/JS.uno
+++ b/Source/Fuse.LocalNotifications/JS.uno
@@ -32,7 +32,7 @@ namespace Fuse.LocalNotifications
 
 		{
 			if(_instance != null) return;
-			Resource.SetGlobalKey(_instance = this, "FuseJS/LocalNotifications");
+			Uno.UX.Resource.SetGlobalKey(_instance = this, "FuseJS/LocalNotifications");
 
 			var onReceivedMessage = new NativeEvent("onReceivedMessage");
 

--- a/Source/Fuse.PushNotifications/JS.uno
+++ b/Source/Fuse.PushNotifications/JS.uno
@@ -41,7 +41,7 @@ namespace Fuse.PushNotifications
 				"registrationSucceeded")
 		{
 			if (_instance != null) return;
-			Resource.SetGlobalKey(_instance = this, "FuseJS/Push");
+			Uno.UX.Resource.SetGlobalKey(_instance = this, "FuseJS/Push");
 
 			// Old-style events for backwards compatibility
 			var onReceivedMessage = new NativeEvent("onReceivedMessage");


### PR DESCRIPTION
Both of these files uses both Uno.UX and Fuse.Reactive (which both
provides a Resource class), but neither clarify which one they want to
use. This leads to a compilation error on usage.

So let's fix it, by adding the fully qualified name here.

How this has gone unnoticed for this long is beyond me. I guess nobody
is using this functionality?

This was extracted out of #1197, but another case was added as well.
