### PR TITLE
Fuse.Controls.WebView: Handles mailto, sms, and tel URLs (iOS & Android)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.Controls.WebView
+- Improves WebView to handle mailto, sms, and tel special URLs supported by system apps on Android & iOS platforms
+
 ### Fuse.LocalNotifications
 - Fix bug on iOS where an app is launched (not restored) from a notification and the notification isn't delivered
 

--- a/Source/Fuse.Controls.WebView/Android/FuseWebViewClient.java
+++ b/Source/Fuse.Controls.WebView/Android/FuseWebViewClient.java
@@ -1,4 +1,6 @@
 package com.fusetools.webview;
+import android.content.Intent;
+import android.net.Uri;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.graphics.Bitmap;
@@ -37,7 +39,14 @@ public class FuseWebViewClient extends WebViewClient
 	{
 		if(tryInterceptUriScheme(url))
 			return true;
-		
+		else if (url.startsWith("mailto:") ||
+					url.startsWith("sms:") ||
+					url.startsWith("tel:")) {
+			Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+			com.fuse.Activity.getRootActivity().startActivity(intent);
+			return true;
+		}
+
 		if(!loadingFinished){
 			redirect = true;
 		}else{

--- a/Source/Fuse.Controls.WebView/iOS/WVNavDelegate.m
+++ b/Source/Fuse.Controls.WebView/iOS/WVNavDelegate.m
@@ -34,6 +34,21 @@
 			}
 		}
 	}
+
+	NSURL *url = navAction.request.URL;
+	if ([url.scheme isEqualToString:@"mailto"] ||
+		 [url.scheme isEqualToString:@"sms"] ||
+		 [url.scheme isEqualToString:@"tel"])
+	{
+		UIApplication *app = [UIApplication sharedApplication];
+		if ([app canOpenURL:url])
+		{
+			[app openURL:url];
+			handler(WKNavigationActionPolicyCancel);
+			return;
+		}
+	}
+
 	handler(WKNavigationActionPolicyAllow);
 }
 


### PR DESCRIPTION
Current <WebView /> markup renders HTML files/pages so well but system special URL links such as "mailto:", "sms:", and "tel:"  do not have any behavior to open system apps. This PR proposes a basic approach to handle those URLs. 

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
