### PR TITLE
Fuse.Text: fix harfbuzz warnings

### DIFF
--- a/Source/Fuse.Text/Implementation/Harfbuzz.uno
+++ b/Source/Fuse.Text/Implementation/Harfbuzz.uno
@@ -116,7 +116,7 @@ namespace Fuse.Text.Implementation
 				float x_offset; float y_offset;
 			} current;
 
-			for (int i = 0; i < glyphCount; ++i)
+			for (unsigned int i = 0; i < glyphCount; ++i)
 			{
 				hb_glyph_info_t info = glyphInfo[i];
 				hb_glyph_position_t pos = glyphPos[i];

--- a/Source/Fuse.Text/Implementation/hb-ft-cached.cc
+++ b/Source/Fuse.Text/Implementation/hb-ft-cached.cc
@@ -4,6 +4,10 @@
 #include FT_FREETYPE_H
 #include FT_ADVANCES_H
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4200) // zero-sized array in struct/union
+#endif
+
 struct font_cache_t
 {
 	FT_Face ft_face;


### PR DESCRIPTION
This fixes compile-time C++ warnings in our Harfbuzz integration.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
