### PR TITLE
Migrate away from Uno.Buffer

### DIFF
--- a/Source/Experimental.TextureLoader/CIL/CilTextureLoader.uno
+++ b/Source/Experimental.TextureLoader/CIL/CilTextureLoader.uno
@@ -7,11 +7,11 @@ namespace Experimental.TextureLoader
 {
 	extern(DOTNET) static class CilTextureLoader
 	{
-		public static void LoadTexture(Buffer buffer, Action<texture2D> callback, string filename)
+		public static void LoadTexture(byte[] buffer, Action<texture2D> callback, string filename)
 		{
 			using(var stream = new Uno.IO.MemoryStream())
 			{
-				var imageBytes = buffer.GetBytes();
+				var imageBytes = buffer;
 				stream.Write(imageBytes, 0, imageBytes.Length);
 				stream.Position = 0;
 

--- a/Source/Experimental.TextureLoader/TextureLoader.uno
+++ b/Source/Experimental.TextureLoader/TextureLoader.uno
@@ -29,7 +29,13 @@ namespace Experimental.TextureLoader
 
 	public static class TextureLoader
 	{
+		[Obsolete("Use the byte[] overload instead")]
 		public static void JpegByteArrayToTexture2D(Buffer arr, Uno.Action<texture2D> callback)
+		{
+			JpegByteArrayToTexture2D(arr.GetBytes(), callback);
+		}
+
+		public static void JpegByteArrayToTexture2D(byte[] arr, Uno.Action<texture2D> callback)
 		{
 			try
 			{
@@ -49,7 +55,13 @@ namespace Experimental.TextureLoader
 			}
 		}
 
+		[Obsolete("Use the byte[] overload instead")]
 		public static void PngByteArrayToTexture2D(Buffer arr, Uno.Action<texture2D> callback)
+		{
+			PngByteArrayToTexture2D(arr.GetBytes(), callback);
+		}
+
+		public static void PngByteArrayToTexture2D(byte[] arr, Uno.Action<texture2D> callback)
 		{
 			try
 			{
@@ -69,7 +81,13 @@ namespace Experimental.TextureLoader
 			}
 		}
 
+		[Obsolete("Use the byte[] overload instead")]
 		public static void ByteArrayToTexture2DFilename(Buffer arr, string filename, Uno.Action<texture2D> callback)
+		{
+			ByteArrayToTexture2DFilename(arr.GetBytes(), filename, callback);
+		}
+
+		public static void ByteArrayToTexture2DFilename(byte[] arr, string filename, Uno.Action<texture2D> callback)
 		{
 			filename = filename.ToLower();
 			if (filename.EndsWith(".png"))
@@ -80,7 +98,13 @@ namespace Experimental.TextureLoader
 				throw new InvalidContentTypeException(filename);
 		}
 
-		public static void ByteArrayToTexture2DContentType(Buffer arr, string contentType, Uno.Action<texture2D> callback)
+		[Obsolete("Use the byte[] overload instead")]
+		public static void ByteArrayToTexture2DContentType(Buffer arr, string filename, Uno.Action<texture2D> callback)
+		{
+			ByteArrayToTexture2DFilename(arr.GetBytes(), filename, callback);
+		}
+
+		public static void ByteArrayToTexture2DContentType(byte[] arr, string contentType, Uno.Action<texture2D> callback)
 		{
 			if (contentType.IndexOf("image/jpeg") != -1 || contentType.IndexOf("image/jpg") != -1)
 				JpegByteArrayToTexture2D(arr, callback);

--- a/Source/Experimental.TextureLoader/TextureLoaderImpl.cpp.uxl
+++ b/Source/Experimental.TextureLoader/TextureLoaderImpl.cpp.uxl
@@ -11,11 +11,11 @@
         <Require Source.Include="uImage/Texture.h" />
         <Require Source.Include="Uno/Support.h" />
 
-        <Method Signature="JpegByteArrayToTexture2D(Uno.Buffer,Experimental.TextureLoader.Callback)">
+        <Method Signature="JpegByteArrayToTexture2D(byte[],Experimental.TextureLoader.Callback)">
             <Body>
                 try
                 {
-                    uBase::Auto<uBase::BufferPtr> bp = new uBase::BufferPtr(U_BUFFER_PTR($0), U_BUFFER_SIZE($0), false);
+                    uBase::Auto<uBase::BufferPtr> bp = new uBase::BufferPtr($0->Ptr(), $0->Length(), false);
                     uBase::Auto<uBase::BufferStream> bs = new uBase::BufferStream(bp, true, false);
                     uBase::Auto<uImage::ImageReader> ir = uImage::Jpeg::CreateReader(bs);
                     uBase::Auto<uImage ::Bitmap> bmp = ir->ReadBitmap();
@@ -42,11 +42,11 @@
             </Body>
         </Method>
 
-        <Method Signature="PngByteArrayToTexture2D(Uno.Buffer,Experimental.TextureLoader.Callback)">
+        <Method Signature="PngByteArrayToTexture2D(byte[],Experimental.TextureLoader.Callback)">
             <Body>
                 try
                 {
-                    uBase::Auto<uBase::BufferPtr> bp = new uBase::BufferPtr(U_BUFFER_PTR($0), U_BUFFER_SIZE($0), false);
+                    uBase::Auto<uBase::BufferPtr> bp = new uBase::BufferPtr($0->Ptr(), $0->Length(), false);
                     uBase::Auto<uBase::BufferStream> bs = new uBase::BufferStream(bp, true, false);
                     uBase::Auto<uImage::ImageReader> ir = uImage::Png::CreateReader(bs);
                     uBase::Auto<uImage::Bitmap> bmp = ir->ReadBitmap();

--- a/Source/Experimental.TextureLoader/TextureLoaderImpl.uno
+++ b/Source/Experimental.TextureLoader/TextureLoaderImpl.uno
@@ -7,7 +7,7 @@ namespace Experimental.TextureLoader
 	static class TextureLoaderImpl
 	{
 		[TargetSpecificImplementation]
-		public static void JpegByteArrayToTexture2D(Buffer arr, Callback callback)
+		public static void JpegByteArrayToTexture2D(byte[] arr, Callback callback)
 		{
 			if defined(DOTNET)
 			{
@@ -16,7 +16,7 @@ namespace Experimental.TextureLoader
 		}
 
 		[TargetSpecificImplementation]
-		public static void PngByteArrayToTexture2D(Buffer arr, Callback callback)
+		public static void PngByteArrayToTexture2D(byte[] arr, Callback callback)
 		{
 			if defined(DOTNET)
 			{

--- a/Source/Fuse.Drawing.Primitives/Rectangle.uno
+++ b/Source/Fuse.Drawing.Primitives/Rectangle.uno
@@ -272,8 +272,8 @@ namespace Fuse.Drawing.Primitives
 				11,11,11,11,11,11,
 			};
 			
-			var bufferVertex = new Buffer(vsr.Length * sizeof(float4));
-			var bufferEdge = new Buffer(vsr.Length * sizeof(float4));
+			var bufferVertex = new byte[vsr.Length * sizeof(float4)];
+			var bufferEdge = new byte[vsr.Length * sizeof(float4)];
 
 			_vertexInfo = new VertexAttributeInfo();
 			_vertexInfo.BufferOffset = 0;
@@ -298,8 +298,8 @@ namespace Fuse.Drawing.Primitives
 					i < (4*3*4+18) ? 2 /*CornerRadius[2]*/ : 3 /*CornerRadius[3]*/)) );
 			}
 
-			_vertexInfo.Buffer.Update(bufferVertex.GetBytes());
-			_edgeInfo.Buffer.Update(bufferEdge.GetBytes());
+			_vertexInfo.Buffer.Update(bufferVertex);
+			_edgeInfo.Buffer.Update(bufferEdge);
 			_bufferDistance.InitDeviceVertex(BufferUsage.Immutable);
 		}
 

--- a/Source/Fuse.Drawing/Internal/BufferCollections.uno
+++ b/Source/Fuse.Drawing/Internal/BufferCollections.uno
@@ -18,7 +18,7 @@ namespace Fuse.Drawing.Internal {
 		Thus each type needs its own derived class! (NOTE: I've just removed the generic for now)
 	*/
 	public class TypedBuffer {
-		protected Buffer back;
+		protected byte[] back;
 		protected int typeSize;
 		//how many items can be stored in back
 		protected int capacity;
@@ -33,14 +33,14 @@ namespace Fuse.Drawing.Internal {
 		
 		protected void Init( int initSize ) {
 			this.capacity = initSize;
-			back = new Buffer( typeSize * initSize );
+			back = new byte[typeSize * initSize];
 		}
 		
 		protected TypedBuffer() {
 			this.typeSize = 0;
 			this.capacity = 0;
 			this.size = 0;
-			back = new Buffer( 0 );
+			back = new byte[0];
 		}
 		
 		IndexBuffer deviceIndex = null;
@@ -48,7 +48,7 @@ namespace Fuse.Drawing.Internal {
 			Creates a device index buffer for this buffer.
 		*/
 		public void InitDeviceIndex( BufferUsage bu = BufferUsage.Dynamic ) {
-			deviceIndex = new IndexBuffer( back.GetBytes(), bu );
+			deviceIndex = new IndexBuffer( back, bu );
 		}
 		public IndexBuffer GetDeviceIndex() {
 			return deviceIndex;
@@ -56,7 +56,7 @@ namespace Fuse.Drawing.Internal {
 		
 		VertexBuffer deviceVertex = null;
 		public void InitDeviceVertex( BufferUsage bu = BufferUsage.Dynamic ) {
-			deviceVertex = new VertexBuffer( back.GetBytes(), bu );
+			deviceVertex = new VertexBuffer( back, bu );
 		}
 		public VertexBuffer GetDeviceVertex() {
 			return deviceVertex;
@@ -64,10 +64,10 @@ namespace Fuse.Drawing.Internal {
 		
 		public void UpdateDevice() {
 			if( deviceIndex != null ) {
-				deviceIndex.Update( back.GetBytes() );
+				deviceIndex.Update( back );
 			} 
 			if( deviceVertex != null ) {
-				deviceVertex.Update( back.GetBytes() );
+				deviceVertex.Update( back );
 			}
 		}
 		
@@ -75,9 +75,13 @@ namespace Fuse.Drawing.Internal {
 			return size;
 		}
 		
-		
-		public Buffer GetBuffer() {
+		public byte[] GetBytes() {
 			return back;
+		}
+
+		[Obsolete("Use GetBytes() instead")]
+		public Buffer GetBuffer() {
+			return new Buffer(back);
 		}
 		
 		/**
@@ -96,8 +100,8 @@ namespace Fuse.Drawing.Internal {
 				return;
 			}
 			int newCap = capacity * 2;
-			var newBuf = new Buffer( typeSize * newCap );
-			for( int i=0; i < back.SizeInBytes; ++i ) {
+			var newBuf = new byte[typeSize * newCap];
+			for( int i=0; i < back.Length; ++i ) {
 				newBuf.Set( i, back[i] );
 			}
 			back = newBuf;

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -216,7 +216,7 @@ namespace Fuse.Elements
 			_vertexPositionBufferValid = false;
 		}
 
-		Buffer _tempBuffer;
+		byte[] _tempBuffer;
 
 		public void Draw(DrawContext dc, float4x4 localToClipTransform, Rect scissorRectInClipSpace)
 		{
@@ -233,7 +233,7 @@ namespace Fuse.Elements
 					_vertexPositionBufferValid = false;
 					_vertexTexCoordBufferValid = false;
 
-					_tempBuffer = new Buffer(_elements.Count * 4 * sizeof(float3));
+					_tempBuffer = new byte[_elements.Count * 4 * sizeof(float3)];
 				}
 
 				if (!_indexBufferValid)
@@ -289,7 +289,7 @@ namespace Fuse.Elements
 
 		void FillIndexBuffer()
 		{
-			var indices = new Buffer(_elements.Count * 6 * sizeof(ushort));
+			var indices = new byte[_elements.Count * 6 * sizeof(ushort)];
 			for (int i = 0; i < _elements.Count; ++i)
 			{
 				indices.Set((i * 6 + 0) * sizeof(ushort), (ushort)(i * 4 + 0));
@@ -303,7 +303,7 @@ namespace Fuse.Elements
 			if (_indexBuffer != null)
 				_indexBuffer.Dispose();
 
-			_indexBuffer = new IndexBuffer(indices.GetBytes(), BufferUsage.Immutable);
+			_indexBuffer = new IndexBuffer(indices, BufferUsage.Immutable);
 		}
 
 		const float CachingRectPaddingAdjustment = 0.5f;
@@ -324,7 +324,7 @@ namespace Fuse.Elements
 				vertexTexCoords.Set((i * 4 + 2) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + size);
 				vertexTexCoords.Set((i * 4 + 3) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + float2(0, size.Y));
 			}
-			_texCoordInfo.Buffer.Update(vertexTexCoords.GetBytes());
+			_texCoordInfo.Buffer.Update(vertexTexCoords);
 		}
 
 		void FillVertexPositionBuffer(DrawContext dc)
@@ -351,7 +351,7 @@ namespace Fuse.Elements
 				vertexPositions.Set((i * 4 + 2) * _positionInfo.BufferStride + _positionInfo.BufferOffset, float3(positionOrigin + right + up, opacity));
 				vertexPositions.Set((i * 4 + 3) * _positionInfo.BufferStride + _positionInfo.BufferOffset, float3(positionOrigin + up, opacity));
 			}
-			_positionInfo.Buffer.Update(vertexPositions.GetBytes());
+			_positionInfo.Buffer.Update(vertexPositions);
 		}
 	}
 }

--- a/Source/Fuse.Elements/Resources/FileImageSource.uno
+++ b/Source/Fuse.Elements/Resources/FileImageSource.uno
@@ -196,7 +196,7 @@ namespace Fuse.Resources
 
 				var data = _file.ReadAllBytes();
 				_orientation = ExifData.FromByteArray(data).Orientation;
-				TextureLoader.ByteArrayToTexture2DFilename(new Buffer(data), _file.Name, SetTexture);
+				TextureLoader.ByteArrayToTexture2DFilename(data, _file.Name, SetTexture);
 				OnChanged();
 			}
 			catch (Exception e)
@@ -262,7 +262,7 @@ namespace Fuse.Resources
 				{
 					var data = _file.ReadAllBytes();
 					_orientation = ExifData.FromByteArray(data).Orientation;
-					TextureLoader.ByteArrayToTexture2DFilename(new Buffer(data), _file.Name, GWDoneCallback);
+					TextureLoader.ByteArrayToTexture2DFilename(data, _file.Name, GWDoneCallback);
 				}
 				catch (Exception e)
 				{

--- a/Source/Fuse.Elements/Resources/HttpImageSource.uno
+++ b/Source/Fuse.Elements/Resources/HttpImageSource.uno
@@ -177,7 +177,7 @@ namespace Fuse.Resources
 			{
 				try
 				{
-					TextureLoader.ByteArrayToTexture2DContentType(new Buffer(_data), _contentType, GWDoneCallback);
+					TextureLoader.ByteArrayToTexture2DContentType(_data, _contentType, GWDoneCallback);
 				}
 				catch (Exception e)
 				{

--- a/Source/Fuse.Text/Renderer.uno
+++ b/Source/Fuse.Text/Renderer.uno
@@ -200,7 +200,7 @@ namespace Fuse.Text
 				if (quadCount > 0)
 				{
 					var vertexBuffer = new VertexBuffer(BufferUsage.Stream);
-					vertexBuffer.Update(CreateVertexBufferData(quads, textures[i].Size).GetBytes());
+					vertexBuffer.Update(CreateVertexBufferData(quads, textures[i].Size));
 
 					_batches.Add(new Batch(i, vertexBuffer, quadCount));
 				}
@@ -283,7 +283,7 @@ namespace Fuse.Text
 				if (length > _length)
 				{
 					_length = Math.Max(length, _length * 2);
-					IndexBuffer.Update(CreateIndexBufferData(_length).GetBytes());
+					IndexBuffer.Update(CreateIndexBufferData(_length));
 				}
 			}
 
@@ -299,10 +299,10 @@ namespace Fuse.Text
 			}
 		}
 
-		static Buffer CreateIndexBufferData(int length)
+		static byte[] CreateIndexBufferData(int length)
 		{
 			var stride = sizeof(ushort) * 6;
-			var buffer = new Buffer(stride * length);
+			var buffer = new byte[stride * length];
 			for (int i = 0; i < length; ++i)
 			{
 				var bufferPos = i * stride;
@@ -317,7 +317,7 @@ namespace Fuse.Text
 			return buffer;
 		}
 
-		static Buffer CreateVertexBufferData(List<Quad> quads, int2 texSize)
+		static byte[] CreateVertexBufferData(List<Quad> quads, int2 texSize)
 		{
 			var stride = sizeof(float2) + sizeof(ushort2);
 			var quadStride = 4 * stride;
@@ -384,7 +384,7 @@ namespace Fuse.Text
 				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texBottom, littleEndian);
 				bufferPos += sizeof(ushort);
 			}
-			return new Buffer(buffer);
+			return buffer;
 		}
 	}
 }


### PR DESCRIPTION
`Uno.Buffer` was deprecated in https://github.com/fuse-open/uno/pull/80, and this migrates to `byte[]` and removes deprecation warnings.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
