### PR TITLE
Migrate to new Android tooling

### DIFF
--- a/Source/Fuse.Elements/Resources/Exif/Exif.uno
+++ b/Source/Fuse.Elements/Resources/Exif/Exif.uno
@@ -167,7 +167,7 @@ namespace Fuse.Resources.Exif
 		@}
 	}
 
-	[Require("Gradle.Dependency.Compile", "com.drewnoakes:metadata-extractor:2.10.1")]
+	[Require("Gradle.Dependency.Implementation", "com.drewnoakes:metadata-extractor:2.10.1")]
 	[ForeignInclude(Language.Java,
 		"java.io.ByteArrayInputStream",
 		"java.io.InputStream",

--- a/Source/Fuse.Maps/Android/MapView.uno
+++ b/Source/Fuse.Maps/Android/MapView.uno
@@ -14,7 +14,7 @@ namespace Fuse.Maps.Android
 		MOVE = 2
 	}
 
-	[Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-maps:12.0.1")]
+	[Require("Gradle.Dependency.Implementation", "com.google.android.gms:play-services-maps:12.0.1")]
 	extern (Android) public class MapView : Fuse.Controls.Native.Android.LeafView, IMapView
 	{
 		public bool IsReady { get; private set; }

--- a/Source/Fuse.PushNotifications/Android/Impl.uno
+++ b/Source/Fuse.PushNotifications/Android/Impl.uno
@@ -31,7 +31,7 @@ namespace Fuse.PushNotifications
 					"java.util.HashMap",
 					"org.json.JSONException",
 					"org.json.JSONObject")]
-	[Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-gcm:9.2.0")]
+	[Require("Gradle.Dependency.Implementation", "com.google.android.gms:play-services-gcm:9.2.0")]
 	extern(Android)
 	internal class AndroidImpl
 	{

--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Context.uno
@@ -5,7 +5,7 @@ using Uno;
 
 namespace Fuse.Scripting.JavaScriptCore
 {
-	[extern(Android) Require("Gradle.Dependency.Compile", "org.webkit:android-jsc:r174650")]
+	[extern(Android) Require("Gradle.Dependency.Implementation", "org.webkit:android-jsc:r174650")]
 	[extern(Android) Require("LinkLibrary", "jsc")]
 	[extern(Android) Require("IncludeDirectory", "@(PACKAGE_DIR:Path)/3rdparty/JavaScriptCore/Headers")]
 	[extern(Android) Require("LinkDirectory", "@(OutputDirectory:Path)/app/build/intermediates/exploded-aar/org.webkit/android-jsc/r174650/jni/${ANDROID_ABI}")]

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -6,5 +6,4 @@
 	<Require Condition="WIN32" SharedLibrary.x64="@('lib/Windows/x64/V8Simple.dll':Path)" />
 	<Require IncludeDirectory="@('.':Path)" />
 	<Require Condition="!Android" LinkLibrary="V8Simple" />
-	<Require Condition="Android" JNI.SystemLibrary="log" />
 </Extensions>

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -1,11 +1,10 @@
 <Extensions Backend="CPlusPlus" Condition="USE_V8">
-	<Require Condition="Android" LinkDirectory="@('lib/Android':Path)" />
 	<Require Condition="Android" JNI.SharedLibrary="@('lib/Android/libV8Simple.so':Path)" />
 	<Require Condition="OSX" LinkDirectory="@('lib/OSX':Path)" />
 	<Require Condition="WIN32" LinkDirectory="@('lib/Windows/$(PlatformShortName)':Path)" />
 	<Require Condition="WIN32" SharedLibrary.x86="@('lib/Windows/x86/V8Simple.dll':Path)" />
 	<Require Condition="WIN32" SharedLibrary.x64="@('lib/Windows/x64/V8Simple.dll':Path)" />
 	<Require IncludeDirectory="@('.':Path)" />
-	<Require LinkLibrary="V8Simple" />
+	<Require Condition="!Android" LinkLibrary="V8Simple" />
 	<Require Condition="Android" JNI.SystemLibrary="log" />
 </Extensions>

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -1,5 +1,5 @@
 <Extensions Backend="CPlusPlus" Condition="USE_V8">
-	<Require Condition="ANDROID" JNI.SharedLibrary="@('lib/Android/libV8Simple.so':Path)" />
+	<Require Condition="ANDROID" SharedLibrary="@('lib/Android/libV8Simple.so':Path)" />
 	<Require Condition="OSX" LinkDirectory="@('lib/OSX':Path)" />
 	<Require Condition="WIN32" LinkDirectory="@('lib/Windows/$(PlatformShortName)':Path)" />
 	<Require Condition="WIN32" SharedLibrary.x86="@('lib/Windows/x86/V8Simple.dll':Path)" />

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -1,9 +1,9 @@
 <Extensions Backend="CPlusPlus" Condition="USE_V8">
-	<Require Condition="Android" JNI.SharedLibrary="@('lib/Android/libV8Simple.so':Path)" />
+	<Require Condition="ANDROID" JNI.SharedLibrary="@('lib/Android/libV8Simple.so':Path)" />
 	<Require Condition="OSX" LinkDirectory="@('lib/OSX':Path)" />
 	<Require Condition="WIN32" LinkDirectory="@('lib/Windows/$(PlatformShortName)':Path)" />
 	<Require Condition="WIN32" SharedLibrary.x86="@('lib/Windows/x86/V8Simple.dll':Path)" />
 	<Require Condition="WIN32" SharedLibrary.x64="@('lib/Windows/x64/V8Simple.dll':Path)" />
 	<Require IncludeDirectory="@('.':Path)" />
-	<Require Condition="!Android" LinkLibrary="V8Simple" />
+	<Require Condition="!ANDROID" LinkLibrary="V8Simple" />
 </Extensions>

--- a/Source/Fuse.Text/Implementation/Harfbuzz.uno
+++ b/Source/Fuse.Text/Implementation/Harfbuzz.uno
@@ -16,7 +16,7 @@ namespace Fuse.Text.Implementation
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("LinkDirectory", "@('../harfbuzz/lib/OSX':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("Xcode.Framework", "CoreText")]
 	[extern(Android) Require("LinkDirectory", "@('../harfbuzz/lib/Android':Path)")]
-	[extern(Android) Require("JNI.StaticLibrary", "@('../harfbuzz/lib/Android/libharfbuzz.a':Path)")]
+	[extern(Android) Require("StaticLibrary", "@('../harfbuzz/lib/Android/libharfbuzz.a':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_WINDOWS) Require("LinkDirectory", "@('../harfbuzz/lib/Windows':Path)")]
 	[extern(!Android) Require("LinkLibrary", "harfbuzz")]
 	[TargetSpecificImplementation]

--- a/Source/Fuse.Text/Implementation/Harfbuzz.uno
+++ b/Source/Fuse.Text/Implementation/Harfbuzz.uno
@@ -15,7 +15,6 @@ namespace Fuse.Text.Implementation
 	[extern(iOS) Require("LinkDirectory", "@('../harfbuzz/lib/iOS':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("LinkDirectory", "@('../harfbuzz/lib/OSX':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("Xcode.Framework", "CoreText")]
-	[extern(Android) Require("LinkDirectory", "@('../harfbuzz/lib/Android':Path)")]
 	[extern(Android) Require("StaticLibrary", "@('../harfbuzz/lib/Android/libharfbuzz.a':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_WINDOWS) Require("LinkDirectory", "@('../harfbuzz/lib/Windows':Path)")]
 	[extern(!Android) Require("LinkLibrary", "harfbuzz")]


### PR DESCRIPTION
Uno 1.10 upgrades to a new version of the Gradle plugin, and renames some build properties to conform. This PR migrates to the new properties.

See https://github.com/fuse-open/uno/pull/73 and https://github.com/fuse-open/uno/pull/101.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
