### PR TITLE
Fuse.Controls.CameraView: fix project references

### DIFF
--- a/Source/Fuse.Controls.CameraView/Fuse.Controls.CameraView.unoproj
+++ b/Source/Fuse.Controls.CameraView/Fuse.Controls.CameraView.unoproj
@@ -3,11 +3,13 @@
   "Publisher": "Fuse Open",
   "Title": "Fuse.Controls.CameraView",
   "Packages": [
-    "Fuse",
-    "FuseJS",
-    "Fuse.ImageTools",
     "Uno.Threading",
     "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse/Fuse.unoproj",
+    "../FuseJS/FuseJS.unoproj",
+    "../Fuse.ImageTools/Fuse.ImageTools.unoproj",
   ],
   "Includes": [
     "*",


### PR DESCRIPTION
We should use project references when referencing projects from the same
repository. This avoids getting errors when building, such as:

    E0000: Multiple projects or packages with the name Fuse.ImageTools

The errors starts happening when building multiple times, when both the
original project and a built package version of it exist. After fixing the
project references, we can build multiple times without getting errors.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
