### PR TITLE
Fuse.Designer: remove use of obsolete attribute

### DIFF
--- a/Source/Fuse.Designer/Attributes.uno
+++ b/Source/Fuse.Designer/Attributes.uno
@@ -1,5 +1,4 @@
 using Uno;
-using Uno.Compiler.ImportServices;
 
 namespace Fuse.Designer
 {
@@ -26,7 +25,7 @@ namespace Fuse.Designer
     public class IconAttribute: Attribute
     {
         public string Path;
-        public IconAttribute([Filename] string path)
+        public IconAttribute(string path)
         {
             Path = path;
         }


### PR DESCRIPTION
FilenameAttribute was deprecated a long time ago, and because using it has no
effect it is safe to remove.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
