### PR TITLE
Share - Android Updates

### DIFF
--- a/Source/Fuse.Share/ShareModule.uno
+++ b/Source/Fuse.Share/ShareModule.uno
@@ -144,8 +144,8 @@ namespace Fuse.Share
 			{
 				var description = args.Length>2 ? "" + args[2] : "";
 				if defined(android)
-				{
-					AndroidShareImpl.ShareFile("file://" + path, type, description);
+				{	
+					AndroidShareImpl.ShareFile(path, type, description);
 					return true;
 				}
 				else if defined(iOS)

--- a/Source/Fuse.Share/ShareModule.uno
+++ b/Source/Fuse.Share/ShareModule.uno
@@ -144,7 +144,7 @@ namespace Fuse.Share
 			{
 				var description = args.Length>2 ? "" + args[2] : "";
 				if defined(android)
-				{	
+				{
 					AndroidShareImpl.ShareFile(path, type, description);
 					return true;
 				}

--- a/Source/Fuse.Share/android/AndroidShareImpl.uno
+++ b/Source/Fuse.Share/android/AndroidShareImpl.uno
@@ -24,6 +24,7 @@ namespace Fuse.Share
 			Intent sendIntent = new Intent();
 			sendIntent.setAction(Intent.ACTION_SEND);
 			sendIntent.putExtra(Intent.EXTRA_TEXT, text);
+			sendIntent.putExtra(Intent.EXTRA_SUBJECT, description);
 			sendIntent.setType("text/plain");
 			com.fuse.Activity.getRootActivity().startActivity(Intent.createChooser(sendIntent, description));
 		@}
@@ -34,6 +35,7 @@ namespace Fuse.Share
 			Context context = com.fuse.Activity.getRootActivity();
 			Intent shareIntent = new Intent();
 			shareIntent.setAction(Intent.ACTION_SEND);
+			shareIntent.putExtra(Intent.EXTRA_SUBJECT, description);
 			//new way for Marshmallow+ (API 23)
 			if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
 				/*

--- a/Source/Fuse.Share/android/AndroidShareImpl.uno
+++ b/Source/Fuse.Share/android/AndroidShareImpl.uno
@@ -9,8 +9,12 @@ namespace Fuse.Share
 					"java.io.File",
 					"java.io.InputStream",
 					"java.io.FileOutputStream",
+					"java.util.ArrayList",
+					"android.os.Build",
 					"android.net.Uri",
+					"android.util.Log", 
 					"android.content.Intent",
+					"android.support.v4.content.FileProvider", 
 					"android.content.Context")]
 	public extern(Android) class AndroidShareImpl
 	{
@@ -30,10 +34,33 @@ namespace Fuse.Share
 			Context context = com.fuse.Activity.getRootActivity();
 			Intent shareIntent = new Intent();
 			shareIntent.setAction(Intent.ACTION_SEND);
-			Uri uri = Uri.parse(path);
-			shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+			//new way for Marshmallow+ (API 23)
+			if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+				/*
+					content:// must be used ~ https://developer.android.com/training/sharing/send
+				*/
+				Uri uri = Uri.parse("content://" + path);
+				File newFile = new File(uri.getPath());
+				/* 
+					Note: The XML file is the only way you can specify the directories 
+					you want to share; you can't programmatically add a directory.
+					~ https://developer.android.com/training/secure-file-sharing/setup-sharing 
+					~ https://developer.android.com/reference/android/support/v4/content/FileProvider
+				*/
+				Uri contentUri = FileProvider.getUriForFile(context,
+												 "@(Activity.Package).share_file_provider",
+												 newFile);
+				shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
+			} else {
+				//for older droids 
+				Uri uri = Uri.parse("file://" + path);
+				shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+			}
+			//give temporary read access to file
+			shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 			shareIntent.setType(mimeType);
 			context.startActivity(Intent.createChooser(shareIntent, description));
+
 		@}
 	}
 }

--- a/Source/Fuse.Share/android/AndroidShareImpl.uxl
+++ b/Source/Fuse.Share/android/AndroidShareImpl.uxl
@@ -1,0 +1,21 @@
+<Extensions Backend="CPlusPlus">
+
+	<ProcessFile Name="ShareFileProvider.java" TargetName="@(Java.SourceDirectory)/com/fuse/fileprovider/ShareFileProvider.java" />
+	
+	<Require Condition="Android" AndroidManifest.ApplicationElement>
+		<![CDATA[
+			<provider
+				android:name="com.fuse.fileprovider.ShareFileProvider"
+				android:authorities="@(Activity.Package).share_file_provider"
+				android:exported="false"
+				android:grantUriPermissions="true">
+				<meta-data
+					android:name="android.support.FILE_PROVIDER_PATHS"
+					android:resource="@xml/android_share_paths" />
+			</provider>
+		]]>
+	</Require>
+
+	<CopyFile Name="android_share_paths.xml" TargetName="app/src/main/res/xml/android_share_paths.xml" />
+
+</Extensions>

--- a/Source/Fuse.Share/android/AndroidShareImpl.uxl
+++ b/Source/Fuse.Share/android/AndroidShareImpl.uxl
@@ -1,6 +1,6 @@
 <Extensions Backend="CPlusPlus">
 
-	<ProcessFile Name="ShareFileProvider.java" TargetName="@(Java.SourceDirectory)/com/fuse/fileprovider/ShareFileProvider.java" />
+	<ProcessFile Condition="Android" Name="ShareFileProvider.java" TargetName="app/src/main/java/com/fuse/fileprovider/ShareFileProvider.java" />
 	
 	<Require Condition="Android" AndroidManifest.ApplicationElement>
 		<![CDATA[
@@ -16,6 +16,6 @@
 		]]>
 	</Require>
 
-	<CopyFile Name="android_share_paths.xml" TargetName="app/src/main/res/xml/android_share_paths.xml" />
+	<CopyFile Condition="Android" Name="android_share_paths.xml" TargetName="app/src/main/res/xml/android_share_paths.xml" />
 
 </Extensions>

--- a/Source/Fuse.Share/android/ShareFileProvider.java
+++ b/Source/Fuse.Share/android/ShareFileProvider.java
@@ -1,0 +1,14 @@
+package com.fuse.fileprovider;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
+ *
+ * See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
+ */
+public class ShareFileProvider extends FileProvider {
+
+    // This class intentionally left blank.
+
+}

--- a/Source/Fuse.Share/android/android_share_paths.xml
+++ b/Source/Fuse.Share/android/android_share_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+
+	<cache-path name="cache" path="." />
+	<files-path name="files" path="." />
+	<external-cache-path name="external_cache_images" path="images" />
+	<cache-path name="cache_images" path="images" />
+
+</paths>


### PR DESCRIPTION
Updated to new android file permission requirements when sharing.
You will need to override the android_share_paths.xml(via AndroidShareImpl.uno) if you would like to add custom paths of folders you would like to give share access to.

https://medium.com/@andrewq/hello-world-eaa996c594b7

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
