### PR TITLE
Temp Android Preview Crash Fix

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.uno
@@ -151,8 +151,12 @@ namespace Fuse.Scripting.V8.Simple
 	extern(USE_V8) static class Debug
 	{
 		public static extern(DOTNET) void SetMessageHandler(JSContext context, IntPtr data, JSDebugMessageHandler messageHandler);
-		public static extern void SendCommand(JSContext context, string command, int length) @{ ::SendJSDebugCommand($0, (uint16_t*)$1->Ptr(), $2); @}
-		public static extern void ProcessMessages(JSContext context) @{ ::ProcessJSDebugMessages($0); @}
+		public static extern void SendCommand(JSContext context, string command, int length) @{ 
+			//::SendJSDebugCommand($0, (uint16_t*)$1->Ptr(), $2); 
+		@}
+		public static extern void ProcessMessages(JSContext context) @{ 
+			//::ProcessJSDebugMessages($0); 
+		@}
 	}
 
 	// -------------------------------------------------------------------------

--- a/Source/Fuse.Scripting.JavaScript/V8/V8SimpleExtensions.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8SimpleExtensions.uno
@@ -266,14 +266,14 @@ namespace Fuse.Scripting.V8
 		}
 		public static extern(CPlusPlus) void SetDebugMessageHandler(JSContext context, Action<JSString> messageHandler)
 		@{
-			::SetJSDebugMessageHandler(
+			/*::SetJSDebugMessageHandler(
 				$0,
 				@{Handle.Create(object):Call($1)},
 				([] (void* data, ::JSString* message) -> void
 				{
 					@{Action<JSString>} handler = (@{Action<JSString>})data;
 					@{Action<JSString>:Of(handler).Call(message)};
-				}));
+				}));*/
 		@}
 	}
 


### PR DESCRIPTION
Fixes the crash of android preview; as the debug calls are deprecated in the newer version of V8, we still need to upgrade the JS debugger calls.


This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
