### PR TITLE
Fix dependency downloads

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 install:
   - npm install
-  - ps: Invoke-WebRequest https://files.fusetools.com/tooling/iyVp8kwQ0vLn-mesa-17.2.3.500.zip -OutFile mesa.zip
+  - ps: Invoke-WebRequest https://www.nuget.org/api/v2/package/mesa3d-x64/18.3.4 -OutFile mesa.zip
   - ps: Expand-Archive mesa.zip mesa
 
 build_script:
@@ -19,7 +19,7 @@ before_test:
       Get-ChildItem -Path Source -Recurse -Include *Test.unoproj | Select-Object -ExpandProperty DirectoryName | Foreach-Object {
         $buildDir = Join-Path $_ build\Test\DotNet
         New-Item -Force -ItemType directory -Path $buildDir | Out-Null
-        Copy-Item -Path mesa\x64\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
+        Copy-Item -Path mesa\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
       }
 
 test_script:

--- a/Source/Fuse.Common/Internal/DesktopFonts.stuff
+++ b/Source/Fuse.Common/Internal/DesktopFonts.stuff
@@ -1,3 +1,3 @@
 if !Android && !iOS {
-/* 22.41MB */ DesktopFonts: "https://files.fusetools.com/tooling/xuTuMXgNyKMr-DesktopFonts.zip"
+/* 22.41MB */ DesktopFonts: "https://www.nuget.org/api/v2/package/fuselibs-desktop-fonts/1.0.0"
 }

--- a/Source/Fuse.Controls.Video/CIL/XamMac.stuff
+++ b/Source/Fuse.Controls.Video/CIL/XamMac.stuff
@@ -1,1 +1,1 @@
-/* 4.28MB */ XamMac: "https://files.fusetools.com/tooling/5xfgNKhw1lmr-XamMac.zip"
+/* 4.28MB */ XamMac: "https://www.nuget.org/api/v2/package/FuseOpen.Xamarin.Mac/3.4.0.2"

--- a/Source/Fuse.Elements/Tests/UX/ImageFill.UrlResource.ux
+++ b/Source/Fuse.Elements/Tests/UX/ImageFill.UrlResource.ux
@@ -1,4 +1,4 @@
 <Rectangle ux:Class="UX.ImageFill.UrlResource">
 	<WhileLoading ux:Name="W"/>
-	<ImageFill Url="https://files.fusetools.com/tooling/HlbWfEK6rfwk-fuselibs_unittest_green.png" MemoryPolicy="UnloadUnused"  StretchMode="PixelPrecise" ux:Name="IF"/>
+	<ImageFill Url="https://github.com/fuse-open/uno/raw/16dbc35b9417c4d9e9d054a275fdbfd2827bc92b/lib/UnoCore/Assets/DefaultIcon.png" MemoryPolicy="UnloadUnused"  StretchMode="PixelPrecise" ux:Name="IF"/>
 </Rectangle>

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cil.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cil.uxl
@@ -2,6 +2,5 @@
 	<Require Condition="HOST_MAC" UnmanagedLibrary="lib/OSX/libV8Simple.dylib" />
 	<Require Condition="HOST_MAC" Assembly="lib/OSX/V8Simple.net.dll" />
 	<Require Condition="HOST_WIN32" Assembly="lib/DotNet/V8Simple.net.dll" />
-	<Require Condition="HOST_WIN32" UnmanagedLibrary.x86="lib/Windows/x86/V8Simple.dll" />
-	<Require Condition="HOST_WIN32" UnmanagedLibrary.x64="lib/Windows/x64/V8Simple.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="lib/Windows/V8Simple.dll" />
 </Extensions>

--- a/Source/Fuse.Scripting.JavaScript/V8/lib/DotNet.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/lib/DotNet.stuff
@@ -1,3 +1,3 @@
 if DOTNET && HOST_WINDOWS {
-/* 0.00MB */ DotNet: "https://files.fusetools.com/tooling/t3gBQQmBwoYG-V8-DotNet.zip"
+/* 0.00MB */ DotNet: "https://www.nuget.org/api/v2/package/V8.Simple-dotnet/5.5.0"
 }

--- a/Source/Fuse.Scripting.JavaScript/V8/lib/OSX.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/lib/OSX.stuff
@@ -1,3 +1,3 @@
 if HOST_MAC {
-/* 7.81MB */ OSX: "https://files.fusetools.com/tooling/IKVrJ1cgLssH-V8-macOS.zip"
+/* 7.81MB */ OSX: "https://www.nuget.org/api/v2/package/V8.Simple-macOS/5.5.0"
 }

--- a/Source/Fuse.Scripting.JavaScript/V8/lib/Windows.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/lib/Windows.stuff
@@ -1,3 +1,3 @@
 if HOST_WINDOWS {
-/* 8.34MB */ Windows: "https://files.fusetools.com/tooling/v6vFc4M0R2IW-V8-Windows.zip"
+/* 8.34MB */ Windows: "https://www.nuget.org/api/v2/package/V8.Simple-win32-x64/5.5.0"
 }

--- a/Source/Fuse.Text/Implementation/ICU.cil.uxl
+++ b/Source/Fuse.Text/Implementation/ICU.cil.uxl
@@ -1,17 +1,10 @@
 <Extensions Backend="CIL">
 	<Define USE_ICU />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/icudt55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/icuin55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/icuio55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/icule55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/iculx55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/icutu55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X86" UnmanagedLibrary="../icu/x86/icu/bin/icuuc55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/icudt55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/icuin55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/icuio55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/icule55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/iculx55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/icutu55.dll" />
-	<Require Condition="HOST_WIN32 && HOST_X64" UnmanagedLibrary="../icu/x64/icu/bin64/icuuc55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/icudt55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/icuin55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/icuio55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/icule55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/iculx55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/icutu55.dll" />
+	<Require Condition="HOST_WIN32" UnmanagedLibrary="../icu/x64/bin64/icuuc55.dll" />
 </Extensions>

--- a/Source/Fuse.Text/harfbuzz/lib/Android.stuff
+++ b/Source/Fuse.Text/harfbuzz/lib/Android.stuff
@@ -1,3 +1,3 @@
 if ANDROID {
-/* 0.21MB */ Android: "https://files.fusetools.com/tooling/pNKuE33KolYV-Harfbuzz-Android.zip"
+/* 0.21MB */ Android: "https://www.nuget.org/api/v2/package/harfbuzz-android-static-armv7/1.2.4"
 }

--- a/Source/Fuse.Text/harfbuzz/lib/OSX.stuff
+++ b/Source/Fuse.Text/harfbuzz/lib/OSX.stuff
@@ -1,3 +1,3 @@
 if HOST_MAC {
-/* 1.59MB */ OSX: "https://files.fusetools.com/tooling/xMmtmmgI4aXy-Harfbuzz-macOS.zip"
+/* 1.59MB */ OSX: "https://www.nuget.org/api/v2/package/fuselibs-harfbuzz-macOS-static/1.2.4"
 }

--- a/Source/Fuse.Text/harfbuzz/lib/iOS.stuff
+++ b/Source/Fuse.Text/harfbuzz/lib/iOS.stuff
@@ -1,3 +1,3 @@
 if iOS {
-/* 0.85MB */ iOS: "https://files.fusetools.com/tooling/1e8qkHS7YB9y-Harfbuzz-iOS.zip"
+/* 0.85MB */ iOS: "https://www.nuget.org/api/v2/package/harfbuzz-iOS-static/1.2.4"
 }

--- a/Source/Fuse.Text/icu/Windows.stuff
+++ b/Source/Fuse.Text/icu/Windows.stuff
@@ -1,4 +1,3 @@
 if HOST_WINDOWS {
-x86: "https://files.fusetools.com/tooling/HtthIgwJ2TdH-icu4c-55_1-Win32-msvc10.zip"
-x64: "https://files.fusetools.com/tooling/Oe1jy7Kg5uTN-icu4c-55_1-Win64-msvc10.zip"
+x64: "https://www.nuget.org/api/v2/package/icu-win32-shared-x64/55.1.0"
 }

--- a/Source/Fuse.Text/icu/iOS.stuff
+++ b/Source/Fuse.Text/icu/iOS.stuff
@@ -1,3 +1,3 @@
 if iOS {
-/* 12.79MB */ iOS: "https://files.fusetools.com/tooling/cphnpuXYu52e-ICU-iOS.zip"
+/* 12.79MB */ iOS: "https://www.nuget.org/api/v2/package/icu-iOS-static/55.1.0"
 }

--- a/Source/Fuse.WebSockets/iOS/SocketRocket/SocketRocket-iOS.stuff
+++ b/Source/Fuse.WebSockets/iOS/SocketRocket/SocketRocket-iOS.stuff
@@ -1,3 +1,3 @@
 if iOS {
-  lib: "https://files.fusetools.com/tooling/W4ITHfzp9cvy-SocketRocket.zip"
+  lib: "https://www.nuget.org/api/v2/package/SocketRocket-iOS-static/0.4.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@fuse-open/uno": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@fuse-open/uno/-/uno-1.11.0.tgz",
-      "integrity": "sha512-IVe3764+N6OHKITUVSM0KNWPBP4E6lxMHpF3U+j1xqSEi94/eQgUKK7+VxbqbKWrkrXpklMzcS87gv+GX/XHAQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@fuse-open/uno/-/uno-1.11.1.tgz",
+      "integrity": "sha512-i2kg2pln4rTv2jE+rm+CUuPFLX2bqfPvgSd3NA/3JZAqzQOJnx/IUnzOtjlAJT4Q1k/um/Wg7F5LaPvgucvtsw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.11.0",
   "description": "Fuselibs is a collection of Uno libraries that provide the UI framework used to build Fuse apps.",
   "devDependencies": {
-    "@fuse-open/uno": "1.11.0"
+    "@fuse-open/uno": "1.11.1"
   },
   "scripts": {
     "build": "uno doctor Source",


### PR DESCRIPTION
It looks like all dependencies hosted on files.fusetools.com are no longer available, effectively breaking all versions of Fuse and Fuse Studio ever released. Hopefully they will come back again soon...

Dependencies are now repackaged and hosted on nuget.org to get things up and running again and to avoid problems with files.fusetools.com in the future.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
