### PR TITLE
Fuse.Gestures: move documentation to the public property

### DIFF
--- a/Source/Fuse.Gestures/Pressed.uno
+++ b/Source/Fuse.Gestures/Pressed.uno
@@ -50,6 +50,7 @@ namespace Fuse.Gestures
 	{
 		public bool Capture { get; set; }
 
+		float2 _pressedPosition;
 		/** Holds the initiall press-down position of the pointer that activated the trigger (read-only).
 
 			This can be used with a `{SnapshotProperty}` binding to place things in response to the pointer position. If the trigger
@@ -71,7 +72,6 @@ namespace Fuse.Gestures
 					</WhilePressed>
 				</Panel>
 		*/
-		float2 _pressedPosition;
 		public float2 PressedPosition
 		{
 			get { return Clicker != null ? Clicker.PressedPosition : _pressedPosition; }


### PR DESCRIPTION
As pointed out [here][1], the reason why this documentation doesn't
appear in the generated docs, is that the documentation comment is
preceeding the internal field, not the public property. So let's remedy
this.

[1]: https://github.com/fuse-open/docs/pull/12#discussion_r201247919

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
