### PR TITLE
fix readonly TextInput

### DIFF
--- a/Source/Fuse.Controls.Native/Android/TextEdit.uno
+++ b/Source/Fuse.Controls.Native/Android/TextEdit.uno
@@ -248,11 +248,15 @@ namespace Fuse.Controls.Native.Android
 			if (_isReadOnly)
 			{
 				SetInputType(Handle, 0);
+				SetFocusable(Handle, false);
+				SetFocusableInTouchMode(Handle, false);
 			}
 			else
 			{
 				SetInputType(Handle, flags);
 				SetImeOptions(Handle, ReturnKeyType);
+				SetFocusable(Handle, true);
+				SetFocusableInTouchMode(Handle, true);
 			}
 		}
 
@@ -337,6 +341,18 @@ namespace Fuse.Controls.Native.Android
 		static void SetImeOptions(Java.Object handle, int value)
 		@{
 			((android.widget.TextView)handle).setImeOptions(value);
+		@}
+
+		[Foreign(Language.Java)]
+		static void SetFocusable(Java.Object handle, bool value)
+		@{
+			((android.widget.EditText)handle).setFocusable(value);
+		@}
+
+		[Foreign(Language.Java)]
+		static void SetFocusableInTouchMode(Java.Object handle, bool value)
+		@{
+			((android.widget.EditText)handle).setFocusableInTouchMode(value);
 		@}
 
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Controls.Native/iOS/Helpers.h
+++ b/Source/Fuse.Controls.Native/iOS/Helpers.h
@@ -43,6 +43,9 @@
 	shouldChangeCharactersInRange:(NSRange)range
 	replacementString:(NSString *)string;
 
+@property (copy) bool (^shouldEditingCallback)(id);
+- (BOOL)textFieldShouldBeginEditing:(UITextField *)textField;
+
 @end
 
 @interface TextViewDelegate : NSObject<UITextViewDelegate>

--- a/Source/Fuse.Controls.Native/iOS/Helpers.mm
+++ b/Source/Fuse.Controls.Native/iOS/Helpers.mm
@@ -124,6 +124,11 @@ static id currentFirstResponder;
 	return newLength <= [self maxLength];
 }
 
+- (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
+{
+	return [self shouldEditingCallback](textField);
+}
+
 @end
 
 @implementation TextViewDelegate


### PR DESCRIPTION
IsReadOnly Property on TextInput both iOS and Android are not function. User still can make an edit and keyboard still showing up. this also fix https://github.com/fuse-open/fuselibs/issues/492

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests