### PR TITLE
Android: switch out calls to GetRootActivity()

### DIFF
--- a/Source/Fuse.Android/AppRoot.uno
+++ b/Source/Fuse.Android/AppRoot.uno
@@ -67,7 +67,7 @@ namespace Fuse.Android
 		[Foreign(Language.Java)]
 		static Java.Object CreateRootView()
 		@{
-			android.widget.FrameLayout frameLayout = new android.widget.FrameLayout(@(Activity.Package).@(Activity.Name).GetRootActivity()) {
+			android.widget.FrameLayout frameLayout = new android.widget.FrameLayout(com.fuse.Activity.getRootActivity()) {
 
 					android.view.MotionEvent _currentEvent;
 

--- a/Source/Fuse.Controls.CameraView/Android/Camera.uno
+++ b/Source/Fuse.Controls.CameraView/Android/Camera.uno
@@ -395,7 +395,7 @@ namespace Fuse.Controls.Android
 		[Foreign(Language.Java)]
 		static Java.Object Create(Java.Object camera, int cameraId, int maxWidth, int maxHeight)
 		@{
-			CameraImpl view = new CameraImpl(@(Activity.Package).@(Activity.Name).GetRootActivity(), (android.hardware.Camera)camera, cameraId, maxWidth, maxHeight);
+			CameraImpl view = new CameraImpl(com.fuse.Activity.getRootActivity(), (android.hardware.Camera)camera, cameraId, maxWidth, maxHeight);
 			view.setLayoutParams(new android.widget.FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
 			return view;
 		@}

--- a/Source/Fuse.Controls.CameraView/Android/CameraView.uno
+++ b/Source/Fuse.Controls.CameraView/Android/CameraView.uno
@@ -305,7 +305,7 @@ namespace Fuse.Controls.Android
 		[Foreign(Language.Java)]
 		static Java.Object Create()
 		@{
-			android.widget.FrameLayout frameLayout = new android.widget.FrameLayout(@(Activity.Package).@(Activity.Name).GetRootActivity());
+			android.widget.FrameLayout frameLayout = new android.widget.FrameLayout(com.fuse.Activity.getRootActivity());
 			frameLayout.setLayoutParams(new android.widget.FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
 			return frameLayout;
 		@}

--- a/Source/Fuse.Controls.CameraView/Android/PhotoPreview.uno
+++ b/Source/Fuse.Controls.CameraView/Android/PhotoPreview.uno
@@ -114,7 +114,7 @@ namespace Fuse.Controls.Android
 		[Foreign(Language.Java)]
 		static Java.Object NewImageView()
 		@{
-			android.widget.ImageView imageView = new android.widget.ImageView(@(Activity.Package).@(Activity.Name).GetRootActivity());
+			android.widget.ImageView imageView = new android.widget.ImageView(com.fuse.Activity.getRootActivity());
 			imageView.setCropToPadding(true);
 			imageView.setScaleType(android.widget.ImageView.ScaleType.CENTER_INSIDE);
 			return imageView;

--- a/Source/Fuse.Controls.DatePicker/Android/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/Android/DatePicker.uno
@@ -146,7 +146,7 @@ namespace Fuse.Controls.Native.Android
 		[Foreign(Language.Java)]
 		static Java.Object Create()
 		@{
-			return new android.widget.DatePicker(@(Activity.Package).@(Activity.Name).GetRootActivity());
+			return new android.widget.DatePicker(com.fuse.Activity.getRootActivity());
 		@}
 
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Controls.Native/Android/CanvasViewGroup.uno
+++ b/Source/Fuse.Controls.Native/Android/CanvasViewGroup.uno
@@ -60,7 +60,7 @@ namespace Fuse.Controls.Native.Android
 		[Foreign(Language.Java)]
 		static Java.Object Instantiate()
 		@{
-			android.widget.FrameLayout frameLayout = new com.fuse.android.views.CanvasViewGroup(@(Activity.Package).@(Activity.Name).GetRootActivity());
+			android.widget.FrameLayout frameLayout = new com.fuse.android.views.CanvasViewGroup(com.fuse.Activity.getRootActivity());
 			frameLayout.setFocusable(true);
 			frameLayout.setFocusableInTouchMode(true);
 			frameLayout.setClipChildren(false);

--- a/Source/Fuse.Controls.TimePicker/Android/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/Android/TimePicker.uno
@@ -90,7 +90,7 @@ namespace Fuse.Controls.Native.Android
 		[Foreign(Language.Java)]
 		static Java.Object Create()
 		@{
-			return new android.widget.TimePicker(@(Activity.Package).@(Activity.Name).GetRootActivity());
+			return new android.widget.TimePicker(com.fuse.Activity.getRootActivity());
 		@}
 
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Nodes/ViewHandle.Android.uno
+++ b/Source/Fuse.Nodes/ViewHandle.Android.uno
@@ -298,7 +298,7 @@ namespace Fuse.Controls.Native
 		[Foreign(Language.Java)]
 		static Java.Object InstantiateViewGroupImpl()
 		@{
-			android.widget.FrameLayout frameLayout = new com.fuse.android.views.ViewGroup(@(Activity.Package).@(Activity.Name).GetRootActivity());
+			android.widget.FrameLayout frameLayout = new com.fuse.android.views.ViewGroup(com.fuse.Activity.getRootActivity());
 			frameLayout.setFocusable(true);
 			frameLayout.setFocusableInTouchMode(true);
 			frameLayout.setClipChildren(false);


### PR DESCRIPTION
Most other code is using `com.fuse.Activity.getRootActivity()`, so switch to using that method in all similar call sites.

`@(Activity.Package).@(Activity.Name).GetRootActivity()` is being deprecated in https://github.com/fuse-open/uno/pull/162.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
