### PR TITLE
Add TypeScript Definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -620,14 +620,14 @@ declare module "FuseJS/FileSystem" {
      *
      *     var FileSystem = require("FuseJS/FileSystem");
      *
-     *     FileSystem.delete("myfile.txt")
+     *     FileSystem.remove("myfile.txt")
      *         .then(function() {
      *             console.log("Delete succeeded");
      *         }, function(error) {
      *             console.log("Unable to delete file");
      *         });
      */
-    function delete(path: string): Promise<void>;
+    function remove(path: string): Promise<void>;
 
     /**
      * Synchronously delete a file.
@@ -636,9 +636,9 @@ declare module "FuseJS/FileSystem" {
      *
      *     var FileSystem = require("FuseJS/FileSystem");
      *
-     *     FileSystem.deleteSync("myfile.txt");
+     *     FileSystem.removeSync("myfile.txt");
      */
-    function deleteSync(path: string): void;
+    function removeSync(path: string): void;
 
     /**
      * Asynchronously check if a file exists.
@@ -1850,7 +1850,7 @@ declare module "FuseJS/Storage" {
      *
      *     var Storage = require("FuseJS/Storage");
      *
-     *     var success = Storage.deleteSync("uselessFile.txt");
+     *     var success = Storage.removeSync("uselessFile.txt");
      *     if(success) {
      *         console.log("Deleted file");
      *     }
@@ -1860,7 +1860,7 @@ declare module "FuseJS/Storage" {
      *
      * > Warning: This call will block until the operation is finished.
      */
-    function deleteSync(filename: string): boolean;
+    function removeSync(filename: string): boolean;
 
     /**
      * Synchrounously reads data from a file inside the application folder.
@@ -1953,7 +1953,10 @@ declare module "FuseJS/Vibration" {
  *     </JavaScript>
  */
 declare module "FuseJS/VideoTools" {
-    function copyVideoToCameraRoll(somePath: string): void;
+    /**
+     * Copy a video to the camera roll.
+     */
+    function copyVideoToCameraRoll(videoPath: string): void;
 }
 
 /**
@@ -2142,10 +2145,10 @@ declare module "FuseJS/Timer" {
      *
      *     callCount++;
      *     if(callCount >= 3) {
-     *         Timer.delete(timerId);
+     *         Timer.destroy(timerId);
      *     }
      * }, 2000, true);
      * ```
      */
-    function delete(timerId: TimerId): void;
+    function destroy(timerId: TimerId): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2128 @@
+/**
+ * Allows you to encode and decode strings from Base64.
+ *
+ * This is useful when passing string to places where some characters are not allowed.
+ *
+ * This example demonstrates simple use of the `Base64` module. The code prints the input string, and the computed Base64 string.
+ *
+ *     var Base64 = require("FuseJS/Base64");
+ *     var string = "Hello, world!";
+ *     console.log(string); //LOG: Hello, world!
+ *     console.log(Base64.encodeAscii(string)); //LOG: SGVsbG8sIHdvcmxkIQ==
+ */
+declare module "FuseJS/Base64" {
+    /**
+     * Decodes the given base64 value to an ASCII string representation
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     console.log(Base64.decodeAscii("SGVsbG8sIHdvcmxkIQ==")); //LOG: Hello, world!
+     */
+    function decodeAscii(value: any): any;
+
+    /**
+     * Decodes the given base64 string to an ArrayBuffer.
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     var buf = Base64.decodeBuffer("NxMAAA==");
+     *     var view = new Int32Array(data);
+     *     // Should print 0x1337
+     *     console.log("0x" + view[0].toString(16));
+     */
+    function decodeBuffer(base64String: any): any;
+
+    /**
+     * Decodes the given base64 Latin-1 encoded bytes to a string.
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     // Prints "hello world"
+     *     console.log(Base64.decodeLatin1("aGVsbG8gd29ybGQ="));
+     */
+    function decodeLatin1(stringToDecode: any): any;
+
+    /**
+     * Decodes the given base64 value to an UTF8 string representation
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     console.log(Base64.encodeUtf8("Rm9vIMKpIGJhcg==")); //LOG: Foo ¸ bar
+     */
+    function decodeUtf8(value: any): any;
+
+    /**
+     * Encodes the given ASCII value to base64 string representation
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     console.log(Base64.encodeAscii("Hello, world!")); //LOG: SGVsbG8sIHdvcmxkIQ==
+     */
+    function encodeAscii(value: any): any;
+
+    /**
+     * Encodes given array buffer to base64.
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *
+     *     var data = new ArrayBuffer(4);
+     *     var view = new Int32Array(data);
+     *     view[0] = 0x1337;
+     *
+     *     console.log(Base64.encodeBuffer(data));
+     */
+    function encodeBuffer(arrayBuffer: any): any;
+
+    /**
+     * Encodes the given string to a Latin-1 base64 string.
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     // Prints "aGVsbG8gd29ybGQ="
+     *     console.log(Base64.encodeLatin1("hello world"));
+     */
+    function encodeLatin1(stringToEncode: any): any;
+
+    /**
+     * Encodes the given UTF8 value to a base64 string representation
+     *
+     *     var Base64 = require("FuseJS/Base64");
+     *     console.log(Base64.encodeUtf8("Foo ¸ bar")); //LOG: Rm9vIMKpIGJhcg==
+     */
+    function encodeUtf8(value: any): any;
+
+}
+
+/**
+ * The bundle API allows you to read files that is bundled with the application, defined in the project file (using `<filename>:Bundle`).
+ *
+ * ```
+ * var Bundle = require("FuseJS/Bundle");
+ * ```
+ *
+ * You can read up on bundling files [here](/docs/assets/bundle)
+ */
+declare module "FuseJS/Bundle" {
+    /**
+     * Asynchronously reads a file from the application bundle and writes it to a destination on the device.
+     * Use with `FuseJS/FileSystem` to determine destination paths. This is useful for extracting html and associated content for local use with WebView via `file://` protocol.
+     *
+     * ```
+     * var Bundle = require("FuseJS/Bundle");
+     * var FileSystem = require("FuseJS/FileSystem");
+     * var Observable = require("FuseJS/Observable");
+     * var urlForWebView = Observable();
+     *
+     * Bundle.extract("assets/site/page.html", FileSystem.dataDirectory + "site/page.html").then(function(resultPath) {
+     *     urlForWebView.value = "file://" + resultPath;
+     * });
+     * ```
+     */
+    function extract(bundleFilePath: any, destinationPath: any): any;
+
+    /**
+     * Fetch a list of every file bundled with the application.
+     *
+     * ```
+     * var Bundle = require("FuseJS/Bundle");
+     *
+     * Bundle.list().then(function(list) {
+     *     //list is an array of paths, such as "assets/image.jpg"
+     * });
+     * ```
+     */
+    function list(): any;
+
+    /**
+     * Asynchronously reads a file from the application bundle
+     *
+     * ```
+     * var Bundle = require("FuseJS/Bundle");
+     *
+     * Bundle.read("someData.json").then(function(contents) {
+     *     console.log(contents);
+     * }, function(error) {
+     *     console.log("Error!", error);
+     * });
+     * ```
+     */
+    function read(filename: any): any;
+
+    /**
+     * Read a bundled file as an ArrayBuffer of bytes
+     *
+     * ```
+     * var Observable = require("FuseJS/Observable");
+     * var Bundle = require("FuseJS/Bundle");
+     * var ImageTools = require("FuseJS/ImageTools");
+     * var imageUrlToDisplay = Observable();
+     *
+     * Bundle.readBuffer("assets/image.jpg").then(function(buffer) {
+     *     //Do something with the image data here
+     * });
+     * ```
+     */
+    function readBuffer(bundlePath: any): any;
+
+    /**
+     * Synchronously reads a file from the application bundle
+     *
+     * ```
+     * var Bundle = require("FuseJS/Bundle");
+     *
+     * var contents = Bundle.readSync("someData.json");
+     * console.log(contents);
+     * ```
+     *
+     * > Warning: This call will block until the operation is finished. If you are reading large amounts of data, use read() instead.
+     */
+    function readSync(filename: any): any;
+
+}
+
+/**
+ * The Environment API allows you to check which platform your app is currently running on.
+ *
+ * You need to add a reference to `"FuseJS"` in your project file to use this feature.
+ *
+ * ## Examples
+ *
+ * You can check which platform your app is running on using the following boolean properties:
+ *
+ *     var Environment = require('FuseJS/Environment');
+ *
+ *     if(Environment.ios)        console.log("Running on iOS");
+ *     if(Environment.android)    console.log("Running on Android");
+ *     if(Environment.preview)    console.log("Running in preview mode");
+ *     if(Environment.mobile)     console.log("Running on iOS or Android");
+ *     if(Environment.desktop)    console.log("Running on desktop");
+ *
+ * You can also get the version of the current *mobile* OS as a
+ * human-readable string using the `mobileOSVersion` property.
+ *
+ *     console.log(Environment.mobileOSVersion);
+ *
+ * > *Note*
+ * >
+ * > On Android, `mobileOSVersion` returns [Build.VERSION.RELEASE](https://developer.android.com/reference/android/os/Build.VERSION.html#RELEASE)
+ * > (e.g. `1.0` or `3.4b5`).
+ * > On iOS, it returns a string in the format of `<major>.<minor>.<patch>`
+ * > (e.g. `9.2.1`).
+ * > Returns an empty string on all other platforms.
+ */
+declare module "FuseJS/Environment" {
+}
+
+/**
+ * Monitor the application lifecycle from JS
+ *
+ * The lifecycle of an app is the time from when your app starts to the time it terminates.
+ * During this time the app will go through a number of states.
+ *
+ * The Lifecycle module allows you query the current state and also be alerted when the
+ * app changes state.
+ *
+ * ## The States
+ *
+ * - Starting
+ * - Background
+ * - Foreground
+ * - Interactive
+ *
+ * ### Starting
+ * Your app start event is implicit, as this is when your JavaScript is first evaluated.
+ *
+ * ### Background
+ * Your app is not the app the user is interactive with right now and so the operating system
+ * has put it into a 'sleep' state.
+ *
+ * Whilst your app is in this state is is not allowed to run code, but you don't have to worry
+ * about this as Fuse will ensure your JS/UX is not doing something when it shouldn't.
+ *
+ * ### Foreground
+ * Your app is front and center on the user's device but they cannot yet interact with it. The
+ * main reason to be in this state is that the user has opened the notification bar on iOS or
+ * Android.
+ *
+ * ### Interactive
+ * Your app is now in the foreground and is accepting input from the user.
+ *
+ * ## Changing States
+ * It would be hard to work with app lifecycle if your app could just jump around the states
+ * randomly. Instead we guarentee the following flow through the states:
+ *
+ * Starting
+ *    
+ * Background ? Foreground ? Interactive
+ *    
+ * Terminating
+ *
+ * ## No `terminating` event
+ * You may be wondering why there is no `terminating` event. The reason is that on mobile
+ * platforms the OS doesn't promise to call you when terminating your app. It may, but in
+ * certain circumstances (low memory, emergency phone call, etc) it won't.
+ *
+ * Because of this the guides for mobile platforms strongly advise against using the `terminating`
+ * event as a cue that the app is shutting down, instead you should be regularly 'checkpointing'
+ * your app so you can recover from any kind of shutdown.
+ *
+ * Given that we are not meant to use it, we have opted not to expose the event.
+ *
+ * This module is an @EventEmitter, so the methods from @EventEmitter can be used to listen to events.
+ *
+ * ## Example
+ *
+ *     <JavaScript>
+ *         var Lifecycle = require('FuseJS/Lifecycle');
+ *
+ *         Lifecycle.on("enteringForeground", function() {
+ *             console.log("on enteringForeground");
+ *         });
+ *         Lifecycle.on("enteringInteractive", function() {
+ *             console.log("on enteringInteractive");
+ *         });
+ *         Lifecycle.on("exitedInteractive", function() {
+ *             console.log("on exitedInteractive");
+ *         });
+ *         Lifecycle.on("enteringBackground", function() {
+ *             console.log("on enteringBackground");
+ *         });
+ *         Lifecycle.on("stateChanged", function(newState) {
+ *             console.log("on stateChanged " + newState);
+ *         });
+ *         module.exports = { lifecycleState: Lifecycle.observe("stateChanged") }
+ *     </JavaScript>
+ *     <StackPanel>
+ *         <Text TextWrapping="Wrap">Open the Fuse Monitor to see the logs</Text>
+ *         <Text>Current lifecycle state:</Text>
+ *         <Text Value="{lifecycleState}" />
+ *     </StackPanel>
+ *
+ * In the above example we're using the @EventEmitter `on` method to listen to the different events.
+ * We're also using the @EventEmitter `observe` method on the `"stateChanged"` event to get an @Observable containing the current state.
+ */
+declare module "FuseJS/Lifecycle" {
+    const BACKGROUND: any;
+
+    const FOREGROUND: any;
+
+    const INTERACTIVE: any;
+
+    /**
+     * Will give you the current state as an integer
+     *
+     *     var Lifecycle = require("FuseJS/Lifecycle");
+     *
+     *     console.log(Lifecycle.state === Lifecycle.BACKGROUND);
+     *     console.log(Lifecycle.state === Lifecycle.FOREGROUND);
+     *     console.log(Lifecycle.state === Lifecycle.INTERACTIVE);
+     */
+    const state: any;
+
+    type Event = "enteringBackground" |
+                 "enteringForeground" |
+                 "enteringInteractive" |
+                 "exitedInteractive" |
+                 "stateChanged";
+
+    /**
+     * Registers a function to be called when one of the following events occur.
+     *
+     * * `"enteringBackground"` - Triggered when the app is leaving the running state and is about to be suspended.
+     * * `"enteringForeground"` - Triggered when the app has left the suspended state and now is running.
+     * You will receive this event when the app starts.
+     * * `"enteringInteractive"` - Triggered when the app is entering a state where it is fully focused and receiving events.
+     * * `"exitedInteractive"` - Triggered when the app is partially obscured or is no longer the focus (e.g. when you drag open the notification bar)
+     * * `"stateChanged"` - Triggered when the app's lifecycle state has changed.
+     */
+    function on(event: Event, callback: () => void): void;
+
+}
+
+/**
+ * Allows the capture of still images from the system camera.
+ *
+ * Images are returned as frozen JavaScript Image objects, consisting of a path, a filename, a width and a height.
+ * Once created or acquired, Images can be passed around to other APIs to use, fetch or alter their underlying data.
+ * All images are temporary "scratch images" until storage has been specified either through publishing to the CameraRoll or other.
+ *
+ * You need to add a reference to `"Fuse.Camera"` in your project file to use this feature.
+ *
+ * On Android using this API will request the CAMERA and WRITE_EXTERNAL_STORAGE permissions.
+ *
+ * ## Example
+ *
+ *     var camera = require('FuseJS/Camera');
+ *     camera.takePicture(640,480).then(function(image)
+ *     {
+ *         //Do things with image here
+ *     }).catch(function(error) {
+ *         //Something went wrong, see error for details
+ *     });
+ */
+declare module "FuseJS/Camera" {
+    /**
+     * Checks if device has permissions to access the camera.
+     */
+    function checkPermissions(): any;
+
+    /**
+     * Requests acccess to the camera
+     */
+    function requestPermissions(): any;
+
+    /**
+     * Starts an OS-specific image capture view and returns a Promise of the resulting Image.
+     *
+     * If the desiredWidth and height parameters are set, returns an Image scaled as close to the specified
+     * width/height as possible while maintaining aspect ratio.
+     *
+     * If no size parameters are given, the taken image will be full-sized as determined by the device camera.
+     *
+     * The image capture view is user-configurable on Android.
+     */
+    function takePicture(desiredWidth: any, desiredHeight: any): any;
+
+}
+
+/**
+ * Allows adding images to- and fetching images from the system image gallery.
+ *
+ * Fuse represents images as frozen JavaScript Image objects, consisting of a path, a filename, a width and a height.
+ * Once created or acquired, Images can be passed around to other APIs to use, fetch or alter their underlying data.
+ * All images are temporary "scratch images" until storage has been specified either through publishing to the CameraRoll or other.
+ *
+ * Using this API on Android will request the `WRITE_EXTERNAL_STORAGE` and `READ_EXTERNAL_STORAGE` permissions.
+ *
+ * > **Note:** You need to add a package reference to `Fuse.CameraRoll` to use this API.
+ *
+ * ## Examples
+ *
+ * Requesting an image from the camera roll:
+ *
+ *     var cameraRoll = require("FuseJS/CameraRoll");
+ *
+ *     cameraRoll.getImage()
+ *         .then(function(image) {
+ *             // Will be called if the user successfully selected an image.
+ *         }, function(error) {
+ *             // Will be called if the user aborted the selection or if an error occurred.
+ *         });
+ *
+ * Taking a picture with the camera and adding it to the camera roll:
+ *
+ *     var cameraRoll = require("FuseJS/CameraRoll");
+ *     var camera = require("FuseJS/Camera");
+ *
+ *     camera.takePicture(640, 480)
+ *         .then(function(image) {
+ *             return cameraRoll.publishImage(image);
+ *         })
+ *         .then(function() {
+ *             // Will be called if the image was successfully added to the camera roll.
+ *         }, function(error) {
+ *             // Will called if an error occurred.
+ *         });
+ *
+ * > **Note**: You also need to add a package reference to `Fuse.Camera` for the above example to work.
+ */
+declare module "FuseJS/CameraRoll" {
+    /**
+     * Adds a copy of the Image instance to the system camera roll.
+     *
+     * On Android this is done by copying the image to the application's public image
+     * storage directory and notifying the media scanner.
+     *
+     * On iOS this is done by uploading a copy of the image to an asset collection
+     * named after the application within the system photo library.
+     */
+    function publishImage(image: any): any;
+
+    /**
+     * Checks if device has permissions to access the camera roll.
+     */
+    function checkPermissions(): any;
+
+    /**
+     * Requests acccess to photo gallery
+     */
+    function requestPermissions(): any;
+
+    /**
+     * Starts an OS-specific image picker view (user-configurable on Android).
+     */
+    function getImage(): any;
+
+}
+
+/**
+ * Provides an interface to the file system.
+ *
+ *     var FileSystem = require("FuseJS/FileSystem");
+ *
+ * Using the asynchronous Promise based functions is recommended to keep your UI responsive,
+ * although synchronous variants are also available if preferred.
+ *
+ * When saving files private to the application you can use the `dataDirectory` property
+ * as a base path.
+ *
+ * ## Example
+ *
+ * This example writes a text to a file, and then reads it back:
+ *
+ *     var FileSystem = require("FuseJS/FileSystem");
+ *     var path = FileSystem.dataDirectory + "/" + "testfile.tmp";
+ *
+ *     FileSystem.writeTextToFile(path, "hello world")
+ *         .then(function() {
+ *             return FileSystem.readTextFromFile(path);
+ *         })
+ *         .then(function(text) {
+ *             console.log("The read file content was: " + text);
+ *         })
+ *         .catch(function(error) {
+ *             console.log("Unable to read file due to error:" + error);
+ *         });
+ */
+declare module "FuseJS/FileSystem" {
+    /**
+     * An object containing paths only exposed on Android devices:
+     *
+     * * `externalCache` -  The directory acquired by calling `Context.getExternalCacheDir()`
+     * * `externalFiles` -  The directory acquired by calling `Context.getExternalFilesDir(null)`
+     * * `cache` -  The directory acquired by calling `Context.getCacheDir()`
+     * * `files` -  The directory acquired by calling `Context.getFilesDir()`
+     */
+    const androidPaths: any;
+
+    /**
+     * A directory to put cached files.
+     *
+     * Note that files in this directory might be automatically removed when space is low, depending on platform.
+     */
+    const cacheDirectory: any;
+
+    /**
+     * A directory to put data files that are private to the application.
+     *
+     * * iOS - The Library directory for the application.
+     * * Android - The directory acquired by calling `Context.getFilesDir()`
+     * * Local preview - `<project dir>/build/Local/Preview/fs_data`
+     *
+     * Note that cleaning or rebuilding your project will delete this directory.
+     */
+    const dataDirectory: any;
+
+    /**
+     * An object containing paths only exposed on iOS devices:
+     *
+     * * `documents` -  Mapped to `NSDocumentDirectory`
+     * * `library` -  Mapped to `NSLibraryDirectory`
+     * * `caches` -  Mapped to `NSCachesDirectory`
+     * * `temp` -  Mapped to `NSTemporaryDirectory`
+     */
+    const iosPaths: any;
+
+    /**
+     * Asynchronously appends a string to a UTF-8 encoded file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.appendTextToFile(FileSystem.dataDirectory + "/" + "myfile.txt", "Hello buddy")
+     *         .then(function() {
+     *             console.log("Successful append");
+     *         }, function(error) {
+     *             console.log(error);
+     *         });
+     */
+    function appendTextToFile(filename: any): any;
+
+    /**
+     * Synchronously appends a string to a UTF-8 encoded file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.appendTextToFileSync("myfile.txt", "Hello buddy");
+     */
+    function appendTextToFileSync(filename: any): any;
+
+    /**
+     * Asynchronously copies a file or directory recursively from source to destination path
+     *
+     * ## Example
+     *
+     *     FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFile("to-be-copied.txt", "hello world")
+     *         .then(function() {
+     *             return FileSystem.copy("to-be-copied.txt", "destination-reached.txt");
+     *         })
+     *         .catch(function(err) {
+     *             console.log("Unable to copy file");
+     *         });
+     */
+    function copy(source: any, destination: any): any;
+
+    /**
+     * Synchronously copies a file or directory recursively from source to destination path
+     *
+     * ## Example
+     *
+     *     FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFileSync("to-be-copied.txt", "hello world");
+     *     FileSystem.copySync("to-be-copied.txt", "destination-reached.txt");
+     */
+    function copySync(source: any, destination: any): any;
+
+    /**
+     * Asynchronously creates a directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.createDirectory(FileSystem.dataDirectory + "/" + "new-directory")
+     *         .then(function() {
+     *             console.log("Directory created!");
+     *         }, function(error) {
+     *             console.log("Error trying to create directory.");
+     *         });
+     */
+    function createDirectory(path: any): any;
+
+    /**
+     * Synchronously creates a directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.createDirectory(FileSystem.dataDirectory + "/" + "new-directory");
+     */
+    function createDirectorySync(path: any): any;
+
+    /**
+     * Asynchronously delete a file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.delete("myfile.txt")
+     *         .then(function() {
+     *             console.log("Delete succeeded");
+     *         }, function(error) {
+     *             console.log("Unable to delete file");
+     *         });
+     */
+    function delete(path: any): any;
+
+    /**
+     * Synchronously delete a file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.deleteSync("myfile.txt");
+     */
+    function deleteSync(path: any): any;
+
+    /**
+     * Asynchronously check if a file exists.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.exists("myfile.txt")
+     *         .then(function(x) {
+     *             console.log(x ? "it's there! =)" : "it's missing :/");
+     *         }, function(error) {
+     *             console.log("Unable to check if file exists");
+     *         });
+     */
+    function exists(path: any): any;
+
+    /**
+     * Synchronously check if a file exists.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     console.log(FileSystem.existsSync("myfile.txt") ? "It's there!" : "It's missing :/");
+     */
+    function existsSync(path: any): any;
+
+    /**
+     * Asynchronously gets info about a directory.
+     *
+     * The returned object has the following properties:
+     *
+     * * `exists` -  a boolean value stating whether the directory exists or not.
+     * * `lastWriteTime` -  A `Date` stating when directory was last changed
+     * * `lastAccessTime` -  A `Date` stating when directory was accessed
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.createDirectorySync("some-dir");
+     *     FileSystem.getDirectoryInfo("some-dir")
+     *         .then(function(dirInfo) {
+     *             console.log("Directory was modified on " + dirInfo.lastWriteTime);
+     *         })
+     *         .catch(function(error) {
+     *             console.log("Failed to get directory info " + error);
+     *         });
+     */
+    function getDirectoryInfo(path: any): any;
+
+    /**
+     * Synchronously gets info about a directory.
+     *
+     * The returned object has the following properties:
+     *
+     * * `exists` -  A boolean value stating whether the directory exists
+     * * `lastWriteTime` -  A `Date` stating when directory was last changed
+     * * `lastAccessTime` -  A `Date` stating when directory was accessed
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.createDirectorySync("some-dir");
+     *     var dirInfo = FileSystem.getDirectoryInfoSync("some-dir");
+     *     console.log("file was modified on " + dirInfo.lastWriteTime);
+     */
+    function getDirectoryInfoSync(path: any): any;
+
+    /**
+     * Asynchronously gets info about a file.
+     *
+     * The returned object has the following properties:
+     *
+     * * `size` -  size of file
+     * * `exists` -  a boolean value stating whether file exists
+     * * `lastWriteTime` -  A `Date` stating when file was last changed
+     * * `lastAccessTime` -  A `Date` stating when file was accessed
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFileSync("some-file.txt", "hello there");
+     *     FileSystem.getFileInfo("some-file.txt")
+     *         .then(function(fileInfo) {
+     *             console.log("file was modified on " + fileInfo.lastWriteTime);
+     *         })
+     *         .catch(function(error) {
+     *             "failed stat " + error
+     *         });
+     */
+    function getFileInfo(path: any): any;
+
+    /**
+     * Synchronously gets info about a file.
+     *
+     * The returned object has the following properties:
+     *
+     * * `exists` -  a boolean value stating whether file exists
+     * * `lastWriteTime` -  A `Date` stating when file was last changed
+     * * `lastAccessTime` -  A `Date` stating when file was accessed
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFileSync("some-file.txt", "hello there");
+     *     var fileInfo = FileSystem.getFileInfoSync("some-file.txt");
+     *     console.log("file was modified on " + fileInfo.lastWriteTime);
+     */
+    function getFileInfoSync(path: any): any;
+
+    /**
+     * Asynchronously list subdirectories in a directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.listDirectories(FileSystem.dataDirectory)
+     *         .then(function(directories) {
+     *             console.log("There are " + directories.length + " subdirectories in directory")
+     *         }, function(error) {
+     *             console.log("Unable to list subdirectories of directory: " + error);
+     *         });
+     */
+    function listDirectories(path: any): any;
+
+    /**
+     * Synchronously list subdirectories in a directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var directories = FileSystem.listDirectoriesSync(FileSystem.dataDirectory);
+     *     console.log("There are " + directories.length + " subdirectories in directory");
+     */
+    function listDirectoriesSync(path: any): any;
+
+    /**
+     * Asynchronously lists both files and subdirectories in a directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.listEntries(FileSystem.dataDirectory)
+     *         .then(function(entries) {
+     *             console.log("There are " + entries.length + " entries in directory")
+     *         }, function(error) {
+     *             console.log("Unable to list entries in directory due to error " + error);
+     *         });
+     */
+    function listEntries(path: any): any;
+
+    /**
+     * Synchronously lists both files and subdirectories in a directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var entries = FileSystem.listEntriesSync(FileSystem.dataDirectory);
+     *     console.log("There are " + entries.length + " entries in directory");
+     */
+    function listEntriesSync(path: any): any;
+
+    /**
+     * Asynchronously list files in directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.listFiles(FileSystem.dataDirectory)
+     *         .then(function(files) {
+     *             console.log("There are " + files.length + " files in directory")
+     *         }, function(error) {
+     *             console.log("Unable to list files in directory due to error " + error);
+     *         });
+     */
+    function listFiles(path: any): any;
+
+    /**
+     * Synchronously list files in directory.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var files = FileSystem.listFilesSync(FileSystem.dataDirectory);
+     *     console.log("There are " + files.length + " files in directory");
+     */
+    function listFilesSync(path: any): any;
+
+    /**
+     * Asynchronously moves a file or directory from source to destination path
+     *
+     * ## Example
+     *
+     *     FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFile("to-be-moved.txt", "hello world")
+     *         .then(function() {
+     *             return FileSystem.move("to-be-moved.txt", "destination-reached.txt");
+     *         })
+     *         .catch(function(err) {
+     *             console.log("Unable to move file");
+     *         });
+     */
+    function move(source: any, destination: any): any;
+
+    /**
+     * Synchronously moves a file or directory from source to destination path
+     *
+     * ## Example
+     *
+     *     FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFileSync("to-be-moved.txt", "hello world");
+     *     FileSystem.moveSync("to-be-moved.txt", "destination-reached.txt");
+     */
+    function moveSync(source: any, destination: any): any;
+
+    /**
+     * Asynchronously reads a file and returns a Promise of an ArrayBuffer with its contents.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.readBufferFromFile("myfile.txt")
+     *         .then(function(contents) {
+     *             console.log(contents);
+     *         }, function(error) {
+     *             console.log(error);
+     *         });
+     */
+    function readBufferFromFile(filename: any): any;
+
+    /**
+     * Synchronously reads a file and returns an ArrayBuffer with its contents.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var data = FileSystem.readBufferFromFileSync("myfile.txt");
+     */
+    function readBufferFromFileSync(filename: any): any;
+
+    /**
+     * Asynchronously reads a file and returns a Promise of its contents.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.readTextFromFile("myfile.txt")
+     *         .then(function(contents) {
+     *             console.log(contents);
+     *         }, function(error) {
+     *             console.log(error);
+     *         });
+     */
+    function readTextFromFile(filename: any): any;
+
+    /**
+     * Synchronously reads a file and returns its contents as a string.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var content =  FileSystem.readTextFromFileSync(FileSystem.dataDirectory + "/" + "myfile.txt");
+     *     console.log("The file contains " + content));
+     */
+    function readTextFromFileSync(filename: any): any;
+
+    /**
+     * Asynchronously writes an `ArrayBuffer` to a file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var data = new ArrayBuffer(4);
+     *     var view = new Int32Array(data);
+     *     view[0] = 0x1337;
+     *
+     *     FileSystem.writeBufferToFile(FileSystem.dataDirectory + "/" + "myfile.txt", data)
+     *         .then(function() {
+     *             console.log("Successful write");
+     *         }, function(error) {
+     *             console.log(error);
+     *         });
+     */
+    function writeBufferToFile(filename: any, data: any): any;
+
+    /**
+     * Synchronously writes an `ArrayBuffer` to a file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     var data = new ArrayBuffer(4);
+     *     var view = new Int32Array(data);
+     *     view[0] = 0x1337;
+     *
+     *     FileSystem.writeBufferToFileSync(FileSystem.dataDirectory + "/" + "myfile.txt", data);
+     */
+    function writeBufferToFileSync(filename: any, data: any): any;
+
+    /**
+     * Asynchronously writes a string to a UTF-8 encoded file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFile(FileSystem.dataDirectory + "/" + "myfile.txt", "Hello buddy")
+     *         .then(function() {
+     *             console.log("Successful write");
+     *         }, function(error) {
+     *             console.log(error);
+     *         });
+     */
+    function writeTextToFile(filename: any, text: any): any;
+
+    /**
+     * Synchronously writes a string to a UTF-8 encoded file.
+     *
+     * ## Example
+     *
+     *     var FileSystem = require("FuseJS/FileSystem");
+     *
+     *     FileSystem.writeTextToFileSync("myfile.txt", "Hello buddy");
+     */
+    function writeTextToFileSync(filename: any, text: any): any;
+
+}
+
+/**
+ * Provides geolocation services.
+ *
+ * Using geolocation services requires device authorization. Including the `Fuse.GeoLocation` package
+ * in your project will trigger a prompt for this authorization when the app is launched.
+ *
+ * Use [startListening](api:fuse/geolocation/geolocation/startlistening_bbef95e2.json)
+ * to get continual location updates. Use
+ * [location](api:fuse/geolocation/geolocation/getlocation.json)
+ * or [getLocation](api:fuse/geolocation/geolocation/getlocationasync_95a738ba.json) for one-time location requests.
+ *
+ * You need to add a reference to `"Fuse.GeoLocation"` in your project file to use this feature.
+ *
+ * This module is an @EventEmitter, so the methods from @EventEmitter can be used to listen to events.
+ *
+ * ## Example
+ *
+ * The following example shows how the different modes of operation can be used:
+ *
+ *     <JavaScript>
+ *         var Observable = require("FuseJS/Observable");
+ *         var GeoLocation = require("FuseJS/GeoLocation");
+ *
+ *         // Immediate
+ *         var immediateLocation = JSON.stringify(GeoLocation.location);
+ *
+ *         // Timeout
+ *         var timeoutLocation = Observable("");
+ *         var timeoutMs = 5000;
+ *         GeoLocation.getLocation(timeoutMs).then(function(location) {
+ *             timeoutLocation.value = JSON.stringify(location);
+ *         }).catch(function(fail) {
+ *             console.log("getLocation fail " + fail);
+ *         });
+ *
+ *         // Continuous
+ *         var continuousLocation = GeoLocation.observe("changed").map(JSON.stringify);
+ *
+ *         GeoLocation.on("error", function(fail) {
+ *             console.log("GeoLocation error " + fail);
+ *         });
+ *
+ *         function startContinuousListener() {
+ *             var intervalMs = 1000;
+ *             var desiredAccuracyInMeters = 10;
+ *             GeoLocation.startListening(intervalMs, desiredAccuracyInMeters);
+ *         }
+ *
+ *         function stopContinuousListener() {
+ *             GeoLocation.stopListening();
+ *         }
+ *
+ *         module.exports = {
+ *             immediateLocation: immediateLocation,
+ *             timeoutLocation: timeoutLocation,
+ *             continuousLocation: continuousLocation,
+ *
+ *             startContinuousListener: startContinuousListener,
+ *             stopContinuousListener: stopContinuousListener
+ *         };
+ *     </JavaScript>
+ *
+ *     <StackPanel>
+ *         <Text>Immediate:</Text>
+ *         <Text Value="{immediateLocation}" />
+ *
+ *         <Text>Timeout:</Text>
+ *         <Text Value="{timeoutLocation}" />
+ *
+ *         <Text>Continuous:</Text>
+ *         <Text Value="{continuousLocation}" />
+ *
+ *         <Button Text="Start continuous listener" Clicked="{startContinuousListener}" />
+ *         <Button Text="Stop continuous listener" Clicked="{stopContinuousListener}" />
+ *     </StackPanel>
+ *
+ * In the above example we're using the @EventEmitter `observe` method to create an @Observable from the
+ * `"changed"` event. We can also listen to changes by using the `on` method, as follows:
+ *
+ *     GeoLocation.on("changed", function(location) { ... })
+ *
+ * Locations returned by this module are JavaScript objects of the following form:
+ *
+ *     {
+ *         latitude: a number measured in decimal degrees,
+ *         longitude: a number measured in decimal degrees,
+ *         accuracy: a number measured in meters
+ *     }
+ *
+ * To handle errors from GeoLocation we can listen to the `"error"` event, as follows:
+ *
+ *     GeoLocation.on("error", function(err) { ... })
+ */
+declare module "FuseJS/GeoLocation" {
+    /**
+     * The last known location.
+     *
+     * The returned object is of the following form:
+     *
+     *     {
+     *         altitude: altitude measured in meters,
+     *         latitude: a number measured in decimal degrees,
+     *         longitude: a number measured in decimal degrees,
+     *         accuracy: a number measured in meters,
+     *         speed: speed measured in meters per second
+     *     }
+     *
+     * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
+     */
+    const location: any;
+
+    /**
+     * The type of authorization request to make to the user.
+     *
+     * This property currently only affects iOS. It should be
+     * set before using the rest of the GeoLocation API.
+     *
+     * Setting this property to `1`, which is also the
+     * default, for example as follows:
+     *
+     *     var GeoLocation = require("FuseJS/GeoLocation");
+     *     GeoLocation.authorizationRequest = 1;
+     *
+     * Means that the app should request permission from the
+     * user to use location services while the app is in the
+     * foreground. Setting it to `2`, as follows:
+     *
+     *     GeoLocation.authorizationRequest = 2;
+     *
+     * Means that the app should request permission from the
+     * user to use location services whenever the app is
+     * running.
+     */
+    const authorizationRequest: any;
+
+    type Event = "changed(location)" |
+                 "error(error)";
+
+    /**
+     * Registers a function to be called when one of the following events occur.
+     *
+     * * `"changed(location)"` - Raised when the location changes.
+     * * `"error(error)"` - Raised when an error occurs.
+     */
+    function on(event: Event, callback: () => void): void;
+
+    /**
+     * Gets the current location as a promise.
+     *
+     * Can optionally be passed a timeout (in milliseconds)
+     * that the promise should be rejected after.
+     *
+     * If successful, the promise is resolved with an object of the following form:
+     *
+     *     {
+     *         altitude: altitude measured in meters,
+     *         latitude: a number measured in decimal degrees,
+     *         longitude: a number measured in decimal degrees,
+     *         accuracy: a number measured in meters,
+     *         speed: speed measured in meters per second
+     *     }
+     *
+     * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
+     */
+    function getLocation(timeout: any): any;
+
+    /**
+     * Starts the GeoLocation listening service.
+     *
+     * [onChanged](api:fuse/geolocation/geolocation/locationchanged_adbb1cba.json)
+     * events will be generated as the location changes.
+     *
+     * Use [stopListening](api:fuse/geolocation/geolocation/stoplistening_bbef95e2.json) to stop the service.
+     *
+     * The parameters here are desired values; the actual interval and accuracy are dependent on the
+     * device.
+     *
+     * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
+     */
+    function startListening(minimumReportInterval: any, desiredAccuracy: any): any;
+
+    /**
+     * Stops the GeoLocation listening service.
+     *
+     * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
+     */
+    function stopListening(): any;
+
+}
+
+/**
+ * Utility methods for common Image manipulation.
+ *
+ * > To use this module, add `Fuse.ImageTools` to your package references in your `.unoproj`.
+ *
+ * Fuse represents images as frozen JavaScript Image objects, consisting of a path, a filename, a width and a height.
+ * Once created or acquired, Images can be passed around to other APIs to use, fetch or alter their underlying data.
+ * All images are temporary "scratch images" until storage has been specified either through publishing to the CameraRoll or other.
+ *
+ * On Android using this API will request the WRITE_EXTERNAL_STORAGE and READ_EXTERNAL_STORAGE permissions.
+ *
+ * ## Example
+ *
+ *     <JavaScript>
+ *         var ImageTools = require("FuseJS/ImageTools");
+ *         var Observable = require("FuseJS/Observable");
+ *
+ *         var imagePath = Observable();
+ *         var base64Image =    "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l" +
+ *                             "EQVQI12MAAoMHIFLAAYSEwIiJgYGZASrI38AAAwBamgM5VF7xgwAAAABJRU5ErkJggg==";
+ *         ImageTools.getImageFromBase64(base64Image)
+ *         .then(function(image) {
+ *             imagePath.value = image.path;
+ *         });
+ *
+ *         module.exports = { test: new Date().toString(), image: imagePath };
+ *     </JavaScript>
+ *     <Image File="{image}" />
+ */
+declare module "FuseJS/ImageTools" {
+    /**
+     * Encodes the given image as a base64 string.
+     *
+     * ## Example
+     *
+     *     // Here we assume that we have an existing `image` object
+     *     var ImageTools = require("FuseJS/ImageTools");
+     *     ImageTools.getBase64FromImage(image)
+     *         .then(function(base64Image) { console.log("The base64 encoded image is \"" + base64Image + "\""); });
+     */
+    function getBase64FromImage(image: any): any;
+
+    /**
+     * Retrieves the underlying image data for an image as an ArrayBuffer.
+     *
+     * ## Example
+     *
+     *     // Here image is expected to be an `Image` object
+     *     var ImageTools = require("FuseJS/ImageTools");
+     *     ImageTools.getBufferFromImage(image)
+     *         .then(function(buf) { console.log("Image contains " + buf.byteLength + " bytes"); });
+     */
+    function getBufferFromImage(image: any): any;
+
+    /**
+     * Crops the supplied `image`, and returns a Promise of the transformed Image.
+     *
+     * The `options` parameter must be an object with one or more of the following properties defined:
+     *
+     * * `x` - X offset for cropped image, from left
+     * * `y` - Y offset for cropped image, from top
+     * * `width` - Width of cropped image
+     * * `height` - Height of cropped image
+     * * `performInPlace` - Boolean value determining whether the existing image will replaced
+     *
+     * ## Example
+     *
+     *     // Here we assume that we have an existing image variable `originalImage`
+     *     var ImageTools = require("FuseJS/ImageTools");
+     *
+     *     var options = {
+     *         width: 10, // Width of cropped image
+     *         height: 10 // Height of cropped image
+     *     };
+     *
+     *     ImageTools.crop(originalImage, options)
+     *         .then(function(newImage) { console.log("Path of cropped image is " + newImage.path); });
+     */
+    function crop(image: any, options: any): any;
+
+    /**
+     * Takes base64 string encoded image data and returns a Promise of an Image.
+     *
+     * ## Example
+     *
+     *     // Here we assume that someBase64ImageString contains a base-64 encoded image
+     *     var ImageTools = require("FuseJS/ImageTools");
+     *     ImageTools.getImageFromBase64(someBase64ImageString);
+     *         .then(function(image) {
+     *             console.log("Scratch path of image is " + image.path);
+     *         });
+     */
+    function getImageFromBase64(base64: any): any;
+
+    /**
+     * Creates a new temporary image file from an ArrayBuffer of image data.
+     *
+     * ## Example
+     *
+     *     var ImageTools = require("FuseJS/ImageTools");
+     *     ImageTools.getImageFromBuffer(imageData).
+     *         then(function (image) { console.log("Scratch image path is: " + image.path); });
+     */
+    function getImageFromBuffer(imageData: any): any;
+
+    /**
+     * Resizes an image using the options provided, and returns a Promise of the transformed Image.
+     *
+     * The `options` parameter must be an object with one or more of the following properties defined:
+     *
+     * * `desiredWidth` - The new width in pixels
+     * * `desiredHeight` - The new height in pixels
+     * * `mode` - The resizing mode, which can be:
+     *   - `ImageTools.IGNORE_ASPECT` - The image is resized exactly to the desired width and height. This is the default.
+     *   - `ImageTools.KEEP_ASPECT`- The image is resized to within the closest size possible to the desired size while still maintaining the original aspect ratio.
+     *   - `ImageTools.SCALE_AND_CROP` - The image is first scaled and centered while maintaining aspect to the closest edge of the desired bounds, then cropped according to the Crop rule. This allows you to make an aspect correct square portrait out of a landscape shot, for instance.
+     * * `performInPlace` - Boolean value determining whether the existing image will replaced
+     *
+     * ## Example
+     *
+     *     // Here we assume that we have an existing image variable `originalImage`
+     *     var ImageTools = require("FuseJS/ImageTools");
+     *
+     *     var options = {
+     *         mode: ImageTools.IGNORE_ASPECT,
+     *         desiredWidth: 320, //The desired width in pixels
+     *         desiredHeight: 240 //The desired height in pixels
+     *     };
+     *
+     *     ImageTools.resize(originalImage, options)
+     *         .then(function(newImage) { console.log("Path of resized image is " + newImage.path); });
+     */
+    function resize(image: any, options: any): any;
+
+}
+
+/**
+ * Create, schedule and react to notifications created locally
+ *
+ * Sometimes you need to alert your user to an event in your app even when your app is not running in the foreground. For this, most mobile devices have some concept of Notifications. This piece of documentation covers 'Local Notifications', which are notifications scheduled from the app itself. 'Push Notifications' are notifications sent from a server elsewhere and are covered [here](api:fuse/pushnotifications/push).
+ *
+ * As with many of our bindings over OS features we like to start with a light API and build up. We are very interested in comments & requests, so do drop by the forums and let us know.
+ *
+ * ## Getting Set Up
+ *
+ * Include the Fuse local notification library by adding the following to your `.unoproj` file
+ *
+ *     "Packages": [
+ *         ...
+ *         "Fuse.LocalNotifications",
+ *         ...
+ *     ],
+ *
+ * This is enough to start using this feature in your apps. Let's look at that now.
+ *
+ * ## App Example
+ *
+ * This is a full Fuse app that uses Local Notifications:
+ *
+ *     <App>
+ *         <JavaScript>
+ *             var LocalNotify = require("FuseJS/LocalNotifications");
+ *
+ *             LocalNotify.on("receivedMessage", function(payload) {
+ *                 console.log("Received Local Notification: " + payload);
+ *                 LocalNotify.clearAllNotifications();
+ *             });
+ *
+ *             function sendLater() {
+ *                 LocalNotify.later(4, "Finally!", "4 seconds is a long time", "hmm?", true);
+ *             }
+ *
+ *             function sendNow() {
+ *                 LocalNotify.now("Boom!", "Just like that", "payload", true);
+ *             }
+ *
+ *             module.exports = {
+ *                 sendNow: sendNow,
+ *                 sendLater: sendLater
+ *             };
+ *         </JavaScript>
+ *         <DockPanel>
+ *             <TopFrameBackground DockPanel.Dock="Top" />
+ *             <ScrollView>
+ *                 <StackPanel>
+ *                     <Button Clicked="{sendNow}" Text="Send notification now" Height="60"/>
+ *                     <Button Clicked="{sendLater}" Text="Send notification in 4 seconds" Height="60"/>
+ *                 </StackPanel>
+ *             </ScrollView>
+ *             <BottomBarBackground DockPanel.Dock="Bottom" />
+ *         </DockPanel>
+ *     </App>
+ *
+ * Let's break down what is happening here.
+ *
+ * ## How it works
+ *
+ * We will skip the `module.exports` and stuff inside the `DockPanel`, as that is better explained in other guides. Let's instead go through the JS.
+ *
+ * After `require`ing our module like normal, we set up a function which will deliver a notification 4 seconds in the future.
+ *
+ *     function sendLater() {
+ *         LocalNotify.later(4, "Finally!", "4 seconds is a long time", "hmm?", true);
+ *     }
+ *
+ * The `later` function take the following parameters:
+ *
+ * - `secondsFromNow`: How long in seconds until the notification fires
+ * - `title`: the `string` which will be the title in the notification when it shows in the device's notification bar
+ * - `body`: the `string` which will be the body of the notification when it shows in the device's notification bar
+ * - `payload`: a string which is not shown in the notification itself, but will be present in the callback.
+ * - `sound`: a `bool` specifying whether or not the device should make the default notification sound when it is shown in the notification bar
+ * - `badgeNumber`: An optional parameter that is only used on iOS, which puts a badge number against the apps icon. This is often used for showing the quantity of 'things' that need the user's attention. For example an email app could show the number of unread emails.
+ *
+ *     function sendNow() {
+ *         LocalNotify.now("Boom!", "Just like that", "payload", true);
+ *     }
+ *
+ * The `now` function is almost identical to the `later` function, except that it doesnt have the `secondsFromNow` parameter.
+ *
+ * One last thing to note about both `now` and `later`, is that they will not deliver a notification to the user if the app is open. Instead, they will trigger the `receivedMessage` event silently.
+ *
+ * Finally, we set up the function that will be called whenever we get a notification, by using the @EventEmitter `on` method to register it.
+ *
+ *     LocalNotify.on("receivedMessage", function(payload) {
+ *         console.log("Received Local Notification: " + payload);
+ *         LocalNotify.clearAllNotifications();
+ *         LocalNotify.clearBadgeNumber();
+ *     });
+ *
+ * This function is called whenever a notification is delivered while the app is open, or when the app is started from a notification the user has selected.
+ *
+ * The `payload` will be a string in JSON format containing the following keys:
+ * - `'title'`: the notification's title as a `string`
+ * - `'body'`: the body text of the notification as a `string`
+ * - `'payload'`: the `string` of data that was sent with the notification.
+ *
+ * `clearAllNotifications()` clears all notifications made by the app that have already been delivered. This can be used to remove similar notifications if one is clicked.
+ *
+ * Last, but not least, `clearBadgeNumber()` clears the little number next to the app icon on the home screen, showing the amount of notifications the app has.
+ *
+ * ## Lifecyle Behavior
+ *
+ * How your notification is treated by the OS depends on the state of the app. If the app is `Interactive`, the notification does not appear, and is instead delivered straight to your running app. If it is not interactive, the OS will create a notification based on the parameters you gave to the `later` or `not` functions. `Interactive` not only means that your app is in the `Foreground`, but that it also is not being obscured by other windows. One example of being in the `Foreground` and not `Interactive`, is when you swipe the status-bar to open the 'Notification Center/Drawer'.
+ *
+ * You can try this with the example app above. Hit the `Send notification in 4 seconds` button, and open the 'Notification Center/Drawer'
+ *
+ * ## Remarks
+ *
+ * This module is an @EventEmitter, so the methods from @EventEmitter can be used to listen to events.
+ *
+ * You need to add a reference to `"Fuse.LocalNotifications"` in your project file to use this feature.
+ */
+declare module "FuseJS/LocalNotifications" {
+    type Event = "receivedMessage";
+
+    /**
+     * Registers a function to be called when one of the following events occur.
+     *
+     * * `"receivedMessage"` -
+     */
+    function on(event: Event, callback: () => void): void;
+
+    /**
+     * Dismisses all currently active notifications created by our app.
+     */
+    function clearAllNotifications(): any;
+
+    /**
+     * Clears the badge number shown on the iOS home screen.
+     */
+    function clearBadgeNumber(): any;
+
+    /**
+     * Displays a notification to the user after the time specified by `secondsFromNow` has passed.
+     */
+    function later(secondsFromNow: any, title: any, body: any, payload: any, sound: any, badgeNumber: any): any;
+
+    /**
+     * Instantly displays a notification to the user.
+     */
+    function now(title: any, body: any, payload: any, sound: any, badgeNumber: any): any;
+
+}
+
+/**
+ * Handles push notification from messaging services.
+ *
+ * This module currently supports APNS (Apple Push Notification Service) and GCM (Google Cloud Messaging).
+ *
+ * Fuse provides support for push-notifications from Firebase Cloud Messaging (FCM) and Apple' Push Notification Service (APNS).
+ *
+ * We have opted for a lightweight consistent interface across iOS and Android which we can easily expand as needed.
+ *
+ * > We are very interested in comments & requests you have on what we have so far so do drop by the forums and let us know.
+ *
+ * ## Setting up the client side
+ *
+ * ### Step 1.
+ *
+ * Include the Fuse push notification library by adding the following to your `.unoproj` file
+ *
+ *     "Packages": [
+ *         ...
+ *         "Fuse.PushNotifications",
+ *         ...
+ *     ],
+ *
+ * ### Step 2. (Only for Android)
+ *
+ * Google notifications require a little extra info.
+ *
+ * Add the following to you `.unoproj`
+ *
+ *     "Android": {
+ *         ...
+ *         "GooglePlay": {
+ *             "SenderID": "111781901112"
+ *         }
+ *         ...
+ *     },
+ *
+ * The `SenderID` is the sender ID from the [Firebase Console](https://console.firebase.google.com).
+ * If you don't yet have a project set up please see the [Android setup](#android-setup) section later in this document.
+ *
+ * ## How this behaves in your app
+ *
+ * Referencing `Fuse.PushNotifications` will do the the following:
+ *
+ * ### Both Platforms
+ *
+ * - You get a callback telling you if the registration succeeded or failed.
+ * - The succeeded callback will contain your unique registration id (also called a token in iOS docs)
+ * - All future received push notifications will fire a callback containing the JSON of the notification.
+ *
+ * All three callbacks mentioned are available in JavaScript and Uno.
+ *
+ * ### Android specific
+ *
+ * - Your SenderID is added to the project's `Manifest.xml` file along with some other plumbing
+ * - When your app starts the app registers with the `GCM` service.
+ *
+ * ### iOS specific
+ *
+ * - When your app starts it registers with APNS. As all access is controlled through Apple's certificate system there is no extra info to provide (we will mention server side a bit later)
+ *
+ * If you wish to disable auto-registration you can place the following in your unoproj file:
+ *
+ *     "iOS": {
+ *         "PushNotifications": {
+ *             "RegisterOnLaunch": false
+ *         }
+ *     },
+ *
+ * You must then register for push notifications by calling `register()` from JS. This option is useful as when the notifications are registered the OS may ask the user for permission to use push notifications and this may be undesirable on launch.
+ *
+ * ## Using the API from JavaScript
+ *
+ * Integrating with notifications from JavaScript is simple. Here is an example that just logs when the callbacks fire:
+ *
+ *     <JavaScript>
+ *         var push = require("FuseJS/Push");
+ *
+ *         push.on("registrationSucceeded", function(regID) {
+ *             console.log("Reg Succeeded: " + regID);
+ *         });
+ *
+ *         push.on("error", function(reason) {
+ *             console.log("Reg Failed: " + reason);
+ *         });
+ *
+ *         push.on("receivedMessage", function(payload) {
+ *             console.log("Recieved Push Notification: " + payload);
+ *         });
+ *     </JavaScript>
+ *
+ * Here we're using the @EventEmitter `on` method to register our functions with the different events.
+ * In a real app we should send our `registration ID` to our server when `registrationSucceeded` is triggered.
+ *
+ * ## Server Side
+ *
+ * When we have our client all set up and ready to go we move on to the backend. For this we are required to jump through the hoops provided by Apple and Google.
+ *
+ * See below for the following guides on how to do this for specific platforms:
+ *
+ * - [iOS Setup](#ios-setup)
+ * - [Android Setup](#android-setup)
+ *
+ * ## The Notification
+ *
+ * We support push notifications in JSON format. When a notification arrives one of two things will happen:
+ *
+ * - If our app has focus, the callback is called right away with the full JSON payload
+ * - If our app doesn't have focus, (and our JSON contains the correct data) we will add a system notification to the notification bar (called the Notification Center in iOS). When the user clicks the notification in the drop down then our app is launched and the notification is delivered.
+ *
+ * Apple and Google's APIs define how the data in the payload is used to populate the system notification, however we have normalized it a little.
+ *
+ * For iOS we'll just include an `aps` entry in the notification's JSON, like so:
+ *
+ *     'aps': {
+ *         alert: {
+ *             'title': 'Well would ya look at that!',
+ *             'body': 'Hello from the server'
+ *         }
+ *     },
+ *
+ * And 'title' and 'body' will be used as the title and body of the system notification.
+ *
+ * For Android we can use exactly the same `'aps'` entry or the alternatively the following:
+ *
+ *     'notification': {
+ *         alert: {
+ *             'title': 'Well would ya look at that!',
+ *             'body': 'Hello from the server'
+ *         }
+ *     },
+ *
+ * The `notification` entry is the standard Google way of doing this but we felt that it wouldn't hurt to support the Apple way too.
+ *
+ * > The current implementation only guarantees the `title` and `body` entries will work. We also always use your app's icon as the notification icon. This is an area we will extend as Fuse matures. If you have specific requests, be sure to let us know!
+ *
+ * ## Message size limits
+ *
+ * Google and Apple has different limits on the size of push notifications.
+ *
+ * - Google limits to 4096 bytes
+ * - Apple limits to 2048 bytes on iOS 8 and up but only 256 bytes on all earlier versions
+ *
+ * ## Remarks
+ *
+ * This module is an @EventEmitter, so the methods from @EventEmitter can be used to listen to events.
+ *
+ * You need to add a reference to `Fuse.PushNotifications` in your project file to use this feature.
+ *
+ * ## Android setup
+ * This section covers how to set up Firebase Push Notifications to the point that you can send test messages to a Fuse App from the Firebase console.
+ *
+ * ### Registering the Sender ID
+ *
+ * - Open the [Firebase Console](https://console.firebase.google.com)
+ * - Select your project or create one if you haven't already
+ * - Click the little cogwheel button at the top of the sidebar, and press "Project settings"
+ * - Navigate to the "Cloud Messaging" tab
+ * - Copy the "Sender ID" into your `.unoproj` like this:
+ *
+ *         "Android": {
+ *             "GooglePlay": {
+ *                 "SenderID": "<Sender ID goes here>"
+ *             }
+ *         }
+ *
+ * ### Registering the Android app
+ *
+ * To enable Firebase Cloud Messaging, you need to register an Android app with your Firebase project.
+ * If you haven't already registered an Android app, follow these steps:
+ *
+ * - From the settings page, click the button to add a new Android app to the project
+ * - A dialog will pop up, prompting you for a package name (the other fields are optional).
+ *     By default, this will be `com.apps.<yourappnameinlowercase>`.
+ *     However, it is recommended to set your own:
+ *
+ *         "Android": {
+ *             "Package": "com.mycompany.myapp",
+ *         }
+ *
+ * - After adding the Android app, you will be prompted to download a `google-services.json` file.
+ *     This can be ignored, as it's not needed for push notifications and can always be downloaded later if needed.
+ *
+ * ### Sending notifications
+ *
+ * After rebuilding your project with the new settings, you should be ready to send and receive push notifications.
+ *
+ * > **Note:** Fuse currently only supports `data` type messages. See [here for details on messages types](https://firebase.google.com/docs/cloud-messaging/concept-options#data_messages) & [this forum post](https://forums.fusetools.com/t/push-notificacions-with-google-firebase-notifications/2910/16) for more information on how we will fix this in future.
+ * > Sadly this means you currently can't use the Firebase Console to send test notifications (they will appear in the notification bar but will fail to reach JS).
+ * > See the example below for an example of how to send messages to a Fuse app.
+ *
+ * When your app starts, the `registrationSucceeded` event will be triggered and you will be given the `regID`
+ * This, along with your FCM Server key, are the details that is needed to send that app a notification.
+ *
+ * Your server key can be found under the "Cloud Messaging" tab of the Project Settings page (where you obtained your Sender ID).
+ *
+ * Here some example Fuse code for sending your app a notification.
+ *
+ *     <JavaScript>
+ *         var API_ACCESS_KEY = '----HARDCODED API KEY----';
+ *         var regID = '----HARDCODED REG ID FROM THE APP YOU ARE SENDING TO----';
+ *
+ *         module.exports.send = function() {
+ *             fetch('https://android.googleapis.com/gcm/send', {
+ *                 method: 'post',
+ *                 headers: {
+ *                     'Authorization': 'key=' + API_ACCESS_KEY,
+ *                     'Content-Type': 'application/json'
+ *                 },
+ *                 body: JSON.stringify({
+ *                     registration_ids: [regID],
+ *                     data: {
+ *                         notification: {
+ *                             alert: {
+ *                                 title: 'Well would ya look at that!',
+ *                                 body: 'Hello from some other app'
+ *                             }
+ *                         },
+ *                         payload: 'anything you like'
+ *                     }
+ *                 })
+ *             }).then(function(response) {
+ *                 console.log(JSON.stringify(response));
+ *             }, function(error) {
+ *                 console.log(error);
+ *             });
+ *         }
+ *     </JavaScript>
+ *
+ * Whilst hardcoding the RegID is clearly not a good idea, it serves the purpose for this simple test.
+ *
+ * ## iOS setup
+ * This section covers how to set up a iOS Push Notifications to the point that you can send messages to a Fuse App.
+ *
+ * ### Certifying your app for ACS
+ *
+ * To do this you need an SSL certificate for your app.
+ *
+ * - Go to the [Apple Dev Center](https://developer.apple.com/account/overview.action)
+ * - Go to the Certificates Section for iOS apps
+ * - In the link bar on the left, under the `Identifiers` section click `App IDs`
+ * - Click the `+` icon in the top right to create a new App ID
+ * - Fill in the details, you cant use push notification with a `Wildcard App ID` so pick `Explicit App ID` and check in XCode for the app's `Bundle ID`
+ * - Under `App Services` enable Push notifications (and anything else you need)
+ * - Click `Continue` and confirm the certificate choice you made.
+ *
+ * ### Syncing XCode
+ *
+ * Your app is now authenticated for Push notifications. Be sure to resync your profiles in XCode before re-building your app.
+ * To do this:
+ * - Open XCode
+ * - In the menu-bar choose `XCode`->`Preferences`
+ * - In the Preferences window view the `Accounts` tab
+ * - In the `Accounts` tab click `View Details` for the relevant Apple ID
+ * - Click the small refresh button in the bottom left of the `View Details` window
+ *
+ * ### Sending Push Notifications to iOS from OSX
+ *
+ * For simple testing you may find that setting up a server is a bit of an overkill. To this end we recommend [NWPusher](https://github.com/noodlewerk/NWPusher). Download the binary [here](https://github.com/noodlewerk/NWPusher/releases/tag/0.6.3) and then follow the following sections from the README
+ *
+ * - `Getting started`
+ * - `Certificate`
+ * - Instead of reading the `Device Token` section simply add the example from above to your UX file
+ * - Finally, follow the `Push from OS X` Section
+ *
+ * Done, you should now be pushing notifications from OSX to iOS.
+ */
+declare module "FuseJS/Push" {
+    type Event = "receivedMessage" |
+                 "error" |
+                 "registrationSucceeded";
+
+    /**
+     * Registers a function to be called when one of the following events occur.
+     *
+     * * `"receivedMessage"` - Triggered when your app receives a notification.
+     * * `"error"` - Called if your app fails to register with the backend.
+     * * `"registrationSucceeded"` - Triggered when your app registers with the APNS or GCM backend.
+     */
+    function on(event: Event, callback: () => void): void;
+
+    /**
+     * Cancels all previously shown notifications.
+     */
+    function clearAllNotifications(): any;
+
+    /**
+     * Clears the badge number shown on the iOS home screen.
+     *
+     * Has no effects on other platforms.
+     */
+    function clearBadgeNumber(): any;
+
+    /**
+     * Registers the app with APNS. Only neccesary if APNS.RegisterOnLaunch was
+     * set to false in the unoproj file.
+     */
+    function register(): any;
+
+}
+
+/**
+ * Cross-app content sharing API for mobile targets.
+ * Supports sharing of raw text, and files with associated [mimetype](http://www.iana.org/assignments/media-types/media-types.xhtml).
+ *
+ * Uses Action Sheet on iOS and ACTION_SEND Intents on Android.
+ *
+ * NB: on iPad, iOS design guidelines requires a point on screen as the origin for the share popover. You can do this by passing a reference to a UX element.
+ *
+ * You need to add a reference to "Fuse.Share" in your project file to use this feature.
+ *
+ * ## Example
+ *
+ *     <JavaScript>
+ *         var Share = require("FuseJS/Share")
+ *         var Camera = require("FuseJS/Camera")
+ *         module.exports = {
+ *             shareFile : function()
+ *             {
+ *                 Camera.takePicture(320,240)
+ *                 .then(function(image) {
+ *                     Share.shareFile(image.path, "image/*", "Photo from Fuse");
+ *                 });
+ *             },
+ *             shareText : function()
+ *             {
+ *                 Share.shareText("https://www.fusetools.com/", "The link to Fuse website");
+ *             }
+ *         }
+ *     </JavaScript>
+ *
+ * ## iPad example
+ *
+ *     <Panel>
+ *         <Button Text="Share" Clicked="{shareText}"/>
+ *         <Panel ux:Name="ShareOrigin" Alignment="Center" Width="1" Height="1" />
+ *         <JavaScript>
+ *             var Share = require("FuseJS/Share")
+ *             module.exports = {
+ *                 shareText : function()
+ *                 {
+ *                     // The iOS popover will use the position of ShareOrigin as its spawn origin
+ *                     Share.shareText("https://www.fusetools.com/", "The link to Fuse website", ShareOrigin);
+ *                 }
+ *             }
+ *         </JavaScript>
+ *     </Panel>
+ */
+declare module "FuseJS/Share" {
+    /**
+     * Share a file to another application by path.
+     */
+    function shareFile(path: any, mimetype: any, description: any): any;
+
+    /**
+     * Share raw text to another application.
+     */
+    function shareText(text: any, description: any): any;
+
+}
+
+/**
+ * The storage API allows you to read from and write to files in the application directory.
+ *
+ *     var Storage = require("FuseJS/Storage");
+ *
+ * Check out the individual functions for documentation on how to use them.
+ */
+declare module "FuseJS/Storage" {
+    /**
+     * Synchrounously deletes a file inside the application folder.
+     *
+     *     var Storage = require("FuseJS/Storage");
+     *
+     *     var success = Storage.deleteSync("uselessFile.txt");
+     *     if(success) {
+     *         console.log("Deleted file");
+     *     }
+     *     else {
+     *         console.log("An error occured!");
+     *     }
+     *
+     * > Warning: This call will block until the operation is finished.
+     */
+    function deleteSync(filename: any): any;
+
+    /**
+     * Synchrounously reads data from a file inside the application folder.
+     *
+     *     var Storage = require("FuseJS/Storage");
+     *
+     *     var contents = Storage.readSync("myfile.txt");
+     *     console.log(contents);
+     *
+     * > Warning: This call will block until the operation is finished. Use read() if you are reading large amounts of data.
+     */
+    function readSync(filename: any): any;
+
+    /**
+     * Asynchronously reads a file and returns a promise of its contents.
+     *
+     *     var Storage = require("FuseJS/Storage");
+     *
+     *     Storage.read("myfile.txt")
+     *         .then(function(contents) {
+     *             console.log(contents);
+     *         }, function(error) {
+     *             console.log(error);
+     *         });
+     */
+    function read(filename: any): any;
+
+    /**
+     * Synchrounously writes data to a file inside the application folder.
+     *
+     *     var Storage = require("FuseJS/Storage");
+     *
+     *     var success = Storage.writeSync("myfile.txt", "Hello from Fuse!");
+     *     if(success) {
+     *         console.log("Successfully wrote to file");
+     *     }
+     *     else {
+     *         console.log("An error occured!");
+     *     }
+     *
+     * > Warning: This call will block until the operation is finished. Use write() if you are writing large amounts of data.
+     */
+    function writeSync(filename: any, contents: any): any;
+
+    /**
+     * Asynchronously writes to a file.
+     *
+     *     var Storage = require("FuseJS/Storage");
+     *
+     *     Storage.write("myfile.txt", "Hello from Fuse!")
+     *         .then(function(succeeded) {
+     *             if(succeeded) {
+     *                 console.log("Successfully wrote to file");
+     *             }
+     *             else {
+     *                 console.log("Couldn't write to file.");
+     *             }
+     *         });
+     */
+    function write(filename: any, contents: any): any;
+
+}
+
+/**
+ * Allows you to use the device's vibration functionality.
+ *
+ * You need to add a reference to `"Fuse.Vibration"` in your project file to use this feature.
+ *
+ * ## Example
+ *
+ * The following code vibrates the device for 0.8 seconds.
+ *
+ *     var vibration = require('FuseJS/Vibration');
+ *     vibration.vibrate(0.8);
+ */
+declare module "FuseJS/Vibration" {
+    function vibrate(seconds: any): any;
+
+}
+
+/**
+ * Utility methods for video files manipulation. Currently only supports moving a video file to the camera roll.
+ *
+ * > To use this module, add `Fuse.CameraView` to your package references in your `.unoproj`.
+ *
+ * ## Example
+ *
+ *     <JavaScript>
+ *         var ImageTools = require("FuseJS/VideoTools");
+ *
+ *         ImageTools.copyVideoToCameraRoll(somePath);
+ *     </JavaScript>
+ */
+declare module "FuseJS/VideoTools" {
+}
+
+/**
+ * Launches the default email app, and starts composing a message.
+ *
+ * You need to add a reference to `"Fuse.Launcher"` in your project file to use this feature.
+ *
+ *     var email = require('FuseJS/Email');
+ *     email.compose("to@example.com", "cc@example.com", "bcc@example.com", "subject", "message");
+ */
+declare module "FuseJS/Email" {
+    /**
+     * Launches the default email app, and starts composing a message.
+     *
+     * compose accepts the following arguments:
+     *
+     * to - The email address(es) of the recipient
+     * cc - The email address(es) of whom to send a carbon copy
+     * bcc - The email address(es) of whom to send a blind carbon copy
+     * subject - The subject of the email
+     * message - The body text of the email
+     *
+     *     var email = require('FuseJS/Email');
+     *     email.compose("to@example.com", "cc@example.com", "bcc@example.com", "subject", "message");
+     */
+    function compose(): any;
+
+}
+
+/**
+ * The InterApp API allows you to launch other apps, as well as respond to being launched via URI schemes.
+ *
+ * This module is an @EventEmitter, so the methods from @EventEmitter can be used to listen to events.
+ *
+ * You need to add a reference to `"Fuse.Launcher"` in your project file to use this feature.
+ *
+ * ## Example
+ *
+ *     var InterApp = require("FuseJS/InterApp");
+ *
+ *     InterApp.on("receivedUri", function(uri) {
+ *         console.log("Launched with URI", uri);
+ *     });
+ *
+ *     InterApp.launchUri("https://fuseopen.com/");
+ *
+ * In the above example we're using the @EventEmitter `on` method to listen to the `"receivedUri"` event.
+ *
+ * For the [receivedUri](api:fuse/reactive/fusejs/interapp/onreceiveduri_968f99a6.json) event to be triggered, you need register a custom URI scheme for your app, as shown [here](articles:basics/uno-projects#mobile-urischeme).
+ */
+declare module "FuseJS/InterApp" {
+    type Event = "receivedUri";
+
+    /**
+     * Registers a function to be called when one of the following events occur.
+     *
+     * * `"receivedUri"` - Called when the app is launched via its own URI scheme.
+     */
+    function on(event: Event, callback: () => void): void;
+
+    /**
+     * Requests the system to launch an app that handles the specified URI.
+     *
+     * Note: you can pass any URI string to `launchUri`, but how it is handled will depend on the target platform and particular device settings.
+     *
+     * There are several common URI schemes that you can use on both Android and iOS:
+     *     http://<website address>
+     *     https://<website address>
+     *     tel:<phone number>
+     *     sms:<phone number>
+     *
+     * Other platform-specific URI schemes are known to be working fine, for example `geo:<parameters>` launches Maps application on Android
+     * and `facetime:<parameters>` launches a Facetime video call on iOS.
+     * More information on supported URI schemes: [on Android](https://developer.android.com/guide/components/intents-common.html) and [on iOS](https://developer.apple.com/library/content/featuredarticles/iPhoneURLScheme_Reference/Introduction/Introduction.html).
+     */
+    function launchUri(uri: any): any;
+
+}
+
+/**
+ * Lanches the map application using the provided `latitude`/`longitude` pair and/or `query`.
+ *
+ * You need to add a reference to `Fuse.Launcher` in your project file to use this feature.
+ *
+ * ## Example
+ *
+ * This code will launch a map centered at the nearest pizza restaurant.
+ *
+ *     var Maps = require("FuseJS/Maps");
+ *     Maps.searchNear(59.9117715, 10.7400957, "pizza restaurant");
+ */
+declare module "FuseJS/Maps" {
+    /**
+     * Launches the map application, centered at the location given by `latitude` and `longitude`.
+     *
+     * ## Example
+     *
+     *     var Maps = require("FuseJS/Maps");
+     *     Maps.openAt(59.9117715, 10.7400957);
+     */
+    function openAt(): any;
+
+    /**
+     * Launches the map application, centered at the location found nearby the given `latitude` and `longitude`,
+     * using `query` as search criteria.
+     *
+     * ## Example
+     *
+     *     var Maps = require("FuseJS/Maps");
+     *     Maps.searchNear(59.9117715, 10.7400957, "Fusetools");
+     */
+    function searchNear(): any;
+
+    /**
+     * Launches the map application, centered at the location found using `query` as search criteria.
+     *
+     * ## Example
+     *
+     *     var Maps = require("FuseJS/Maps");
+     *     Maps.searchNearby("Fusetools");
+     */
+    function searchNearby(): any;
+
+}
+
+/**
+ * The Phone API allows you to launch your device's built-in
+ * phone app and make calls.
+ *
+ * You need to add a reference to `"Fuse.Launcher"` in your project file to use this feature.
+ *
+ * ## Example
+ *
+ *     var phone = require("FuseJS/Phone");
+ *     phone.call("+47 123 45 678");
+ */
+declare module "FuseJS/Phone" {
+    /**
+     * Launches your device's phone app with the specified number.
+     *
+     * ## Example
+     *
+     *     var phone = require("FuseJS/Phone");
+     *     phone.call("+47 123 45 678");
+     */
+    function call(number: any): any;
+
+}
+
+/**
+ * The Timer API lets you schedule functions to be executed after a given time.
+ *
+ *     var Timer = require("FuseJS/Timer");
+ *
+ *     Timer.create(function() {
+ *         console.log("This will run once, after 3 seconds");
+ *     }, 3000, false);
+ *
+ *     Timer.create(function() {
+ *         console.log("This will run every 10 seconds until forever");
+ *     }, 10000, true);
+ */
+declare module "FuseJS/Timer" {
+    /**
+     * Schedules `func` to be called after `time` milliseconds.
+     *
+     *     var Timer = require("FuseJS/Timer");
+     *     Timer.create(function() {
+     *         console.log("This will run once, after 3 seconds");
+     *     }, 3000, false);
+     *
+     *     Timer.create(function() {
+     *         console.log("This will run every 10 seconds until forever");
+     *     }, 10000, true);
+     */
+    function create(func: any, time: any, repeat: any): any;
+
+    /**
+     * Deletes/unschedules a running timer.
+     *
+     * ```
+     * var Timer = require("FuseJS/Timer");
+     *
+     * var callCount = 0;
+     *
+     * var timerId = Timer.create(function() {
+     *     console.log("This will happen 3 times.");
+     *
+     *     callCount++;
+     *     if(callCount >= 3) {
+     *         Timer.delete(timerId);
+     *     }
+     * }, 2000, true);
+     * ```
+     */
+    function delete(timerId: any): any;
+
+}
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,6 @@ declare module "FuseJS/Base64" {
      *     console.log(Base64.encodeUtf8("Foo ¸ bar")); //LOG: Rm9vIMKpIGJhcg==
      */
     function encodeUtf8(value: string): string;
-
 }
 
 /**
@@ -171,7 +170,6 @@ declare module "FuseJS/Bundle" {
      * > Warning: This call will block until the operation is finished. If you are reading large amounts of data, use read() instead.
      */
     function readSync(filename: string): string;
-
 }
 
 /**
@@ -334,7 +332,6 @@ declare module "FuseJS/Lifecycle" {
      * * `"stateChanged"` - Triggered when the app's lifecycle state has changed.
      */
     function on(event: Event, callback: () => void): void;
-
 }
 
 /**
@@ -380,7 +377,6 @@ declare module "FuseJS/Camera" {
      * The image capture view is user-configurable on Android.
      */
     function takePicture(desiredWidth?: number, desiredHeight?: number): Promise<any>;
-
 }
 
 /**
@@ -450,7 +446,6 @@ declare module "FuseJS/CameraRoll" {
      * Starts an OS-specific image picker view (user-configurable on Android).
      */
     function getImage(): Promise<any>;
-
 }
 
 /**
@@ -974,7 +969,6 @@ declare module "FuseJS/FileSystem" {
      *     FileSystem.writeTextToFileSync("myfile.txt", "Hello buddy");
      */
     function writeTextToFileSync(filename: string, text: string): void;
-
 }
 
 /**
@@ -1164,7 +1158,6 @@ declare module "FuseJS/GeoLocation" {
      * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
      */
     function stopListening(): void;
-
 }
 
 /**
@@ -1300,7 +1293,6 @@ declare module "FuseJS/ImageTools" {
      *         .then(function(newImage) { console.log("Path of resized image is " + newImage.path); });
      */
     function resize(image: any, options: any): Promise<any>;
-
 }
 
 /**
@@ -1449,7 +1441,6 @@ declare module "FuseJS/LocalNotifications" {
      * Instantly displays a notification to the user.
      */
     function now(title: string, body: string, payload: any, sound: boolean, badgeNumber?: any): void;
-
 }
 
 /**
@@ -1750,7 +1741,6 @@ declare module "FuseJS/Push" {
      * set to false in the unoproj file.
      */
     function register(): void;
-
 }
 
 /**
@@ -1810,7 +1800,6 @@ declare module "FuseJS/Share" {
      * Share raw text to another application.
      */
     function shareText(text: string, description: string): void;
-
 }
 
 /**
@@ -1897,7 +1886,6 @@ declare module "FuseJS/Storage" {
      *         });
      */
     function write(filename: string, contents: string): Promise<boolean>;
-
 }
 
 /**
@@ -1914,7 +1902,6 @@ declare module "FuseJS/Storage" {
  */
 declare module "FuseJS/Vibration" {
     function vibrate(seconds: number): void;
-
 }
 
 /**
@@ -1958,7 +1945,6 @@ declare module "FuseJS/Email" {
      *     email.compose("to@example.com", "cc@example.com", "bcc@example.com", "subject", "message");
      */
     function compose(to: string, cc: string, bcc: string, subject: string, message: string): void;
-
 }
 
 /**
@@ -2008,7 +1994,6 @@ declare module "FuseJS/InterApp" {
      * More information on supported URI schemes: [on Android](https://developer.android.com/guide/components/intents-common.html) and [on iOS](https://developer.apple.com/library/content/featuredarticles/iPhoneURLScheme_Reference/Introduction/Introduction.html).
      */
     function launchUri(uri: string): void;
-
 }
 
 /**
@@ -2054,7 +2039,6 @@ declare module "FuseJS/Maps" {
      *     Maps.searchNearby("Fusetools");
      */
     function searchNearby(query: string): void;
-
 }
 
 /**
@@ -2078,7 +2062,6 @@ declare module "FuseJS/Phone" {
      *     phone.call("+47 123 45 678");
      */
     function call(number: string): void;
-
 }
 
 /**
@@ -2130,6 +2113,4 @@ declare module "FuseJS/Timer" {
      * ```
      */
     function delete(timerId: TimerId): void;
-
 }
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -478,6 +478,13 @@ declare module "FuseJS/CameraRoll" {
  *         });
  */
 declare module "FuseJS/FileSystem" {
+    interface AndroidPaths {
+        externalCache: string;
+        externalFiles: string;
+        cache: string;
+        files: string;
+    }
+
     /**
      * An object containing paths only exposed on Android devices:
      *
@@ -486,7 +493,7 @@ declare module "FuseJS/FileSystem" {
      * * `cache` -  The directory acquired by calling `Context.getCacheDir()`
      * * `files` -  The directory acquired by calling `Context.getFilesDir()`
      */
-    const androidPaths: string[];
+    const androidPaths: AndroidPaths;
 
     /**
      * A directory to put cached files.
@@ -506,6 +513,13 @@ declare module "FuseJS/FileSystem" {
      */
     const dataDirectory: string;
 
+    interface IosPaths {
+        documents: string;
+        library: string;
+        caches: string;
+        temp: string;
+    }
+
     /**
      * An object containing paths only exposed on iOS devices:
      *
@@ -514,7 +528,7 @@ declare module "FuseJS/FileSystem" {
      * * `caches` -  Mapped to `NSCachesDirectory`
      * * `temp` -  Mapped to `NSTemporaryDirectory`
      */
-    const iosPaths: string[];
+    const iosPaths: IosPaths;
 
     /**
      * Asynchronously appends a string to a UTF-8 encoded file.
@@ -653,6 +667,12 @@ declare module "FuseJS/FileSystem" {
      */
     function existsSync(path: string): boolean;
 
+    interface DirectoryInfo {
+        exists: boolean;
+        lastWriteTime: Date;
+        lastAccessTime: Date;
+    }
+
     /**
      * Asynchronously gets info about a directory.
      *
@@ -675,7 +695,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Failed to get directory info " + error);
      *         });
      */
-    function getDirectoryInfo(path: string): Promise<any>;
+    function getDirectoryInfo(path: string): Promise<DirectoryInfo>;
 
     /**
      * Synchronously gets info about a directory.
@@ -694,7 +714,14 @@ declare module "FuseJS/FileSystem" {
      *     var dirInfo = FileSystem.getDirectoryInfoSync("some-dir");
      *     console.log("file was modified on " + dirInfo.lastWriteTime);
      */
-    function getDirectoryInfoSync(path: string): any;
+    function getDirectoryInfoSync(path: string): DirectoryInfo;
+
+    interface FileInfo {
+        size: number;
+        exists: boolean;
+        lastWriteTime: Date;
+        lastAccessTime: Date;
+    }
 
     /**
      * Asynchronously gets info about a file.
@@ -719,7 +746,7 @@ declare module "FuseJS/FileSystem" {
      *             "failed stat " + error
      *         });
      */
-    function getFileInfo(path: string): Promise<any>;
+    function getFileInfo(path: string): Promise<FileInfo>;
 
     /**
      * Synchronously gets info about a file.
@@ -738,7 +765,7 @@ declare module "FuseJS/FileSystem" {
      *     var fileInfo = FileSystem.getFileInfoSync("some-file.txt");
      *     console.log("file was modified on " + fileInfo.lastWriteTime);
      */
-    function getFileInfoSync(path: string): any;
+    function getFileInfoSync(path: string): FileInfo;
 
     /**
      * Asynchronously list subdirectories in a directory.
@@ -1065,6 +1092,14 @@ declare module "FuseJS/FileSystem" {
  *     GeoLocation.on("error", function(err) { ... })
  */
 declare module "FuseJS/GeoLocation" {
+    interface Location {
+        altitude: number;
+        latitude: number;
+        longitude: number;
+        accuracy: number;
+        speed: number;
+    }
+
     /**
      * The last known location.
      *
@@ -1080,7 +1115,7 @@ declare module "FuseJS/GeoLocation" {
      *
      * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
      */
-    const location: any;
+    const location: Location;
 
     /**
      * The type of authorization request to make to the user.
@@ -1135,7 +1170,7 @@ declare module "FuseJS/GeoLocation" {
      *
      * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
      */
-    function getLocation(timeout: number): any;
+    function getLocation(timeout: number): Location;
 
     /**
      * Starts the GeoLocation listening service.

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module "FuseJS/Base64" {
      *     var Base64 = require("FuseJS/Base64");
      *     console.log(Base64.decodeAscii("SGVsbG8sIHdvcmxkIQ==")); //LOG: Hello, world!
      */
-    function decodeAscii(value: any): any;
+    function decodeAscii(value: string): string;
 
     /**
      * Decodes the given base64 string to an ArrayBuffer.
@@ -28,7 +28,7 @@ declare module "FuseJS/Base64" {
      *     // Should print 0x1337
      *     console.log("0x" + view[0].toString(16));
      */
-    function decodeBuffer(base64String: any): any;
+    function decodeBuffer(base64String: string): ArrayBuffer;
 
     /**
      * Decodes the given base64 Latin-1 encoded bytes to a string.
@@ -37,15 +37,15 @@ declare module "FuseJS/Base64" {
      *     // Prints "hello world"
      *     console.log(Base64.decodeLatin1("aGVsbG8gd29ybGQ="));
      */
-    function decodeLatin1(stringToDecode: any): any;
+    function decodeLatin1(stringToDecode: string): string;
 
     /**
      * Decodes the given base64 value to an UTF8 string representation
      *
      *     var Base64 = require("FuseJS/Base64");
-     *     console.log(Base64.encodeUtf8("Rm9vIMKpIGJhcg==")); //LOG: Foo ¸ bar
+     *     console.log(Base64.encodeUtf8("Rm9vIMKpIGJhcg==")); //LOG: Foo Â¸ bar
      */
-    function decodeUtf8(value: any): any;
+    function decodeUtf8(value: string): string;
 
     /**
      * Encodes the given ASCII value to base64 string representation
@@ -53,7 +53,7 @@ declare module "FuseJS/Base64" {
      *     var Base64 = require("FuseJS/Base64");
      *     console.log(Base64.encodeAscii("Hello, world!")); //LOG: SGVsbG8sIHdvcmxkIQ==
      */
-    function encodeAscii(value: any): any;
+    function encodeAscii(value: string): string;
 
     /**
      * Encodes given array buffer to base64.
@@ -66,7 +66,7 @@ declare module "FuseJS/Base64" {
      *
      *     console.log(Base64.encodeBuffer(data));
      */
-    function encodeBuffer(arrayBuffer: any): any;
+    function encodeBuffer(arrayBuffer: ArrayBuffer): string;
 
     /**
      * Encodes the given string to a Latin-1 base64 string.
@@ -75,15 +75,15 @@ declare module "FuseJS/Base64" {
      *     // Prints "aGVsbG8gd29ybGQ="
      *     console.log(Base64.encodeLatin1("hello world"));
      */
-    function encodeLatin1(stringToEncode: any): any;
+    function encodeLatin1(stringToEncode: string): string;
 
     /**
      * Encodes the given UTF8 value to a base64 string representation
      *
      *     var Base64 = require("FuseJS/Base64");
-     *     console.log(Base64.encodeUtf8("Foo ¸ bar")); //LOG: Rm9vIMKpIGJhcg==
+     *     console.log(Base64.encodeUtf8("Foo Â¸ bar")); //LOG: Rm9vIMKpIGJhcg==
      */
-    function encodeUtf8(value: any): any;
+    function encodeUtf8(value: string): string;
 
 }
 
@@ -112,7 +112,7 @@ declare module "FuseJS/Bundle" {
      * });
      * ```
      */
-    function extract(bundleFilePath: any, destinationPath: any): any;
+    function extract(bundleFilePath: string, destinationPath: string): Promise<string>;
 
     /**
      * Fetch a list of every file bundled with the application.
@@ -125,7 +125,7 @@ declare module "FuseJS/Bundle" {
      * });
      * ```
      */
-    function list(): any;
+    function list(): Promise<string[]>;
 
     /**
      * Asynchronously reads a file from the application bundle
@@ -140,7 +140,7 @@ declare module "FuseJS/Bundle" {
      * });
      * ```
      */
-    function read(filename: any): any;
+    function read(filename: string): Promise<string>;
 
     /**
      * Read a bundled file as an ArrayBuffer of bytes
@@ -156,7 +156,7 @@ declare module "FuseJS/Bundle" {
      * });
      * ```
      */
-    function readBuffer(bundlePath: any): any;
+    function readBuffer(bundlePath: string): Promise<ArrayBuffer>;
 
     /**
      * Synchronously reads a file from the application bundle
@@ -170,7 +170,7 @@ declare module "FuseJS/Bundle" {
      *
      * > Warning: This call will block until the operation is finished. If you are reading large amounts of data, use read() instead.
      */
-    function readSync(filename: any): any;
+    function readSync(filename: string): string;
 
 }
 
@@ -205,6 +205,12 @@ declare module "FuseJS/Bundle" {
  * > Returns an empty string on all other platforms.
  */
 declare module "FuseJS/Environment" {
+    const ios: boolean;
+    const android: boolean;
+    const preview: boolean;
+    const mobile: boolean;
+    const desktop: boolean;
+    const mobileOSVersion: string;
 }
 
 /**
@@ -296,11 +302,9 @@ declare module "FuseJS/Environment" {
  * We're also using the @EventEmitter `observe` method on the `"stateChanged"` event to get an @Observable containing the current state.
  */
 declare module "FuseJS/Lifecycle" {
-    const BACKGROUND: any;
-
-    const FOREGROUND: any;
-
-    const INTERACTIVE: any;
+    const BACKGROUND: number;
+    const FOREGROUND: number;
+    const INTERACTIVE: number;
 
     /**
      * Will give you the current state as an integer
@@ -311,7 +315,7 @@ declare module "FuseJS/Lifecycle" {
      *     console.log(Lifecycle.state === Lifecycle.FOREGROUND);
      *     console.log(Lifecycle.state === Lifecycle.INTERACTIVE);
      */
-    const state: any;
+    const state: number;
 
     type Event = "enteringBackground" |
                  "enteringForeground" |
@@ -358,12 +362,12 @@ declare module "FuseJS/Camera" {
     /**
      * Checks if device has permissions to access the camera.
      */
-    function checkPermissions(): any;
+    function checkPermissions(): boolean;
 
     /**
      * Requests acccess to the camera
      */
-    function requestPermissions(): any;
+    function requestPermissions(): boolean;
 
     /**
      * Starts an OS-specific image capture view and returns a Promise of the resulting Image.
@@ -375,7 +379,7 @@ declare module "FuseJS/Camera" {
      *
      * The image capture view is user-configurable on Android.
      */
-    function takePicture(desiredWidth: any, desiredHeight: any): any;
+    function takePicture(desiredWidth?: number, desiredHeight?: number): Promise<any>;
 
 }
 
@@ -430,22 +434,22 @@ declare module "FuseJS/CameraRoll" {
      * On iOS this is done by uploading a copy of the image to an asset collection
      * named after the application within the system photo library.
      */
-    function publishImage(image: any): any;
+    function publishImage(image: any): void;
 
     /**
      * Checks if device has permissions to access the camera roll.
      */
-    function checkPermissions(): any;
+    function checkPermissions(): boolean;
 
     /**
      * Requests acccess to photo gallery
      */
-    function requestPermissions(): any;
+    function requestPermissions(): boolean;
 
     /**
      * Starts an OS-specific image picker view (user-configurable on Android).
      */
-    function getImage(): any;
+    function getImage(): Promise<any>;
 
 }
 
@@ -487,14 +491,14 @@ declare module "FuseJS/FileSystem" {
      * * `cache` -  The directory acquired by calling `Context.getCacheDir()`
      * * `files` -  The directory acquired by calling `Context.getFilesDir()`
      */
-    const androidPaths: any;
+    const androidPaths: string[];
 
     /**
      * A directory to put cached files.
      *
      * Note that files in this directory might be automatically removed when space is low, depending on platform.
      */
-    const cacheDirectory: any;
+    const cacheDirectory: string;
 
     /**
      * A directory to put data files that are private to the application.
@@ -505,7 +509,7 @@ declare module "FuseJS/FileSystem" {
      *
      * Note that cleaning or rebuilding your project will delete this directory.
      */
-    const dataDirectory: any;
+    const dataDirectory: string;
 
     /**
      * An object containing paths only exposed on iOS devices:
@@ -515,7 +519,7 @@ declare module "FuseJS/FileSystem" {
      * * `caches` -  Mapped to `NSCachesDirectory`
      * * `temp` -  Mapped to `NSTemporaryDirectory`
      */
-    const iosPaths: any;
+    const iosPaths: string[];
 
     /**
      * Asynchronously appends a string to a UTF-8 encoded file.
@@ -531,7 +535,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log(error);
      *         });
      */
-    function appendTextToFile(filename: any): any;
+    function appendTextToFile(filename: string, contents: string): Promise<void>;
 
     /**
      * Synchronously appends a string to a UTF-8 encoded file.
@@ -542,7 +546,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     FileSystem.appendTextToFileSync("myfile.txt", "Hello buddy");
      */
-    function appendTextToFileSync(filename: any): any;
+    function appendTextToFileSync(filename: string, contents: string): void;
 
     /**
      * Asynchronously copies a file or directory recursively from source to destination path
@@ -559,7 +563,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to copy file");
      *         });
      */
-    function copy(source: any, destination: any): any;
+    function copy(source: string, destination: string): Promise<void>;
 
     /**
      * Synchronously copies a file or directory recursively from source to destination path
@@ -571,7 +575,7 @@ declare module "FuseJS/FileSystem" {
      *     FileSystem.writeTextToFileSync("to-be-copied.txt", "hello world");
      *     FileSystem.copySync("to-be-copied.txt", "destination-reached.txt");
      */
-    function copySync(source: any, destination: any): any;
+    function copySync(source: string, destination: string): void;
 
     /**
      * Asynchronously creates a directory.
@@ -587,7 +591,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Error trying to create directory.");
      *         });
      */
-    function createDirectory(path: any): any;
+    function createDirectory(path: string): Promise<void>;
 
     /**
      * Synchronously creates a directory.
@@ -598,7 +602,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     FileSystem.createDirectory(FileSystem.dataDirectory + "/" + "new-directory");
      */
-    function createDirectorySync(path: any): any;
+    function createDirectorySync(path: string): void;
 
     /**
      * Asynchronously delete a file.
@@ -614,7 +618,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to delete file");
      *         });
      */
-    function delete(path: any): any;
+    function delete(path: string): Promise<void>;
 
     /**
      * Synchronously delete a file.
@@ -625,7 +629,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     FileSystem.deleteSync("myfile.txt");
      */
-    function deleteSync(path: any): any;
+    function deleteSync(path: string): void;
 
     /**
      * Asynchronously check if a file exists.
@@ -641,7 +645,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to check if file exists");
      *         });
      */
-    function exists(path: any): any;
+    function exists(path: string): Promise<boolean>;
 
     /**
      * Synchronously check if a file exists.
@@ -652,7 +656,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     console.log(FileSystem.existsSync("myfile.txt") ? "It's there!" : "It's missing :/");
      */
-    function existsSync(path: any): any;
+    function existsSync(path: string): boolean;
 
     /**
      * Asynchronously gets info about a directory.
@@ -676,7 +680,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Failed to get directory info " + error);
      *         });
      */
-    function getDirectoryInfo(path: any): any;
+    function getDirectoryInfo(path: string): Promise<any>;
 
     /**
      * Synchronously gets info about a directory.
@@ -695,7 +699,7 @@ declare module "FuseJS/FileSystem" {
      *     var dirInfo = FileSystem.getDirectoryInfoSync("some-dir");
      *     console.log("file was modified on " + dirInfo.lastWriteTime);
      */
-    function getDirectoryInfoSync(path: any): any;
+    function getDirectoryInfoSync(path: string): any;
 
     /**
      * Asynchronously gets info about a file.
@@ -720,7 +724,7 @@ declare module "FuseJS/FileSystem" {
      *             "failed stat " + error
      *         });
      */
-    function getFileInfo(path: any): any;
+    function getFileInfo(path: string): Promise<any>;
 
     /**
      * Synchronously gets info about a file.
@@ -739,7 +743,7 @@ declare module "FuseJS/FileSystem" {
      *     var fileInfo = FileSystem.getFileInfoSync("some-file.txt");
      *     console.log("file was modified on " + fileInfo.lastWriteTime);
      */
-    function getFileInfoSync(path: any): any;
+    function getFileInfoSync(path: string): any;
 
     /**
      * Asynchronously list subdirectories in a directory.
@@ -755,7 +759,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to list subdirectories of directory: " + error);
      *         });
      */
-    function listDirectories(path: any): any;
+    function listDirectories(path: string): Promise<string[]>;
 
     /**
      * Synchronously list subdirectories in a directory.
@@ -767,7 +771,7 @@ declare module "FuseJS/FileSystem" {
      *     var directories = FileSystem.listDirectoriesSync(FileSystem.dataDirectory);
      *     console.log("There are " + directories.length + " subdirectories in directory");
      */
-    function listDirectoriesSync(path: any): any;
+    function listDirectoriesSync(path: string): string[];
 
     /**
      * Asynchronously lists both files and subdirectories in a directory.
@@ -783,7 +787,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to list entries in directory due to error " + error);
      *         });
      */
-    function listEntries(path: any): any;
+    function listEntries(path: string): Promise<string[]>;
 
     /**
      * Synchronously lists both files and subdirectories in a directory.
@@ -795,7 +799,7 @@ declare module "FuseJS/FileSystem" {
      *     var entries = FileSystem.listEntriesSync(FileSystem.dataDirectory);
      *     console.log("There are " + entries.length + " entries in directory");
      */
-    function listEntriesSync(path: any): any;
+    function listEntriesSync(path: string): string[];
 
     /**
      * Asynchronously list files in directory.
@@ -811,7 +815,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to list files in directory due to error " + error);
      *         });
      */
-    function listFiles(path: any): any;
+    function listFiles(path: string): Promise<string[]>;
 
     /**
      * Synchronously list files in directory.
@@ -823,7 +827,7 @@ declare module "FuseJS/FileSystem" {
      *     var files = FileSystem.listFilesSync(FileSystem.dataDirectory);
      *     console.log("There are " + files.length + " files in directory");
      */
-    function listFilesSync(path: any): any;
+    function listFilesSync(path: string): string[];
 
     /**
      * Asynchronously moves a file or directory from source to destination path
@@ -840,7 +844,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log("Unable to move file");
      *         });
      */
-    function move(source: any, destination: any): any;
+    function move(source: string, destination: string): Promise<void>;
 
     /**
      * Synchronously moves a file or directory from source to destination path
@@ -852,7 +856,7 @@ declare module "FuseJS/FileSystem" {
      *     FileSystem.writeTextToFileSync("to-be-moved.txt", "hello world");
      *     FileSystem.moveSync("to-be-moved.txt", "destination-reached.txt");
      */
-    function moveSync(source: any, destination: any): any;
+    function moveSync(source: string, destination: string): Promise<void>;
 
     /**
      * Asynchronously reads a file and returns a Promise of an ArrayBuffer with its contents.
@@ -868,7 +872,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log(error);
      *         });
      */
-    function readBufferFromFile(filename: any): any;
+    function readBufferFromFile(filename: string): Promise<ArrayBuffer>;
 
     /**
      * Synchronously reads a file and returns an ArrayBuffer with its contents.
@@ -879,7 +883,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     var data = FileSystem.readBufferFromFileSync("myfile.txt");
      */
-    function readBufferFromFileSync(filename: any): any;
+    function readBufferFromFileSync(filename: string): ArrayBuffer;
 
     /**
      * Asynchronously reads a file and returns a Promise of its contents.
@@ -895,7 +899,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log(error);
      *         });
      */
-    function readTextFromFile(filename: any): any;
+    function readTextFromFile(filename: string): Promise<string>;
 
     /**
      * Synchronously reads a file and returns its contents as a string.
@@ -907,7 +911,7 @@ declare module "FuseJS/FileSystem" {
      *     var content =  FileSystem.readTextFromFileSync(FileSystem.dataDirectory + "/" + "myfile.txt");
      *     console.log("The file contains " + content));
      */
-    function readTextFromFileSync(filename: any): any;
+    function readTextFromFileSync(filename: string): string;
 
     /**
      * Asynchronously writes an `ArrayBuffer` to a file.
@@ -927,7 +931,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log(error);
      *         });
      */
-    function writeBufferToFile(filename: any, data: any): any;
+    function writeBufferToFile(filename: string, data: ArrayBuffer): Promise<void>;
 
     /**
      * Synchronously writes an `ArrayBuffer` to a file.
@@ -942,7 +946,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     FileSystem.writeBufferToFileSync(FileSystem.dataDirectory + "/" + "myfile.txt", data);
      */
-    function writeBufferToFileSync(filename: any, data: any): any;
+    function writeBufferToFileSync(filename: string, data: ArrayBuffer): void;
 
     /**
      * Asynchronously writes a string to a UTF-8 encoded file.
@@ -958,7 +962,7 @@ declare module "FuseJS/FileSystem" {
      *             console.log(error);
      *         });
      */
-    function writeTextToFile(filename: any, text: any): any;
+    function writeTextToFile(filename: string, text: string): Promise<void>;
 
     /**
      * Synchronously writes a string to a UTF-8 encoded file.
@@ -969,7 +973,7 @@ declare module "FuseJS/FileSystem" {
      *
      *     FileSystem.writeTextToFileSync("myfile.txt", "Hello buddy");
      */
-    function writeTextToFileSync(filename: any, text: any): any;
+    function writeTextToFileSync(filename: string, text: string): void;
 
 }
 
@@ -1106,10 +1110,10 @@ declare module "FuseJS/GeoLocation" {
      * user to use location services whenever the app is
      * running.
      */
-    const authorizationRequest: any;
+    const authorizationRequest: number;
 
-    type Event = "changed(location)" |
-                 "error(error)";
+    type Event = "changed" |
+                 "error";
 
     /**
      * Registers a function to be called when one of the following events occur.
@@ -1117,7 +1121,7 @@ declare module "FuseJS/GeoLocation" {
      * * `"changed(location)"` - Raised when the location changes.
      * * `"error(error)"` - Raised when an error occurs.
      */
-    function on(event: Event, callback: () => void): void;
+    function on(event: Event, callback: (arg: any) => void): void;
 
     /**
      * Gets the current location as a promise.
@@ -1137,7 +1141,7 @@ declare module "FuseJS/GeoLocation" {
      *
      * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
      */
-    function getLocation(timeout: any): any;
+    function getLocation(timeout: number): any;
 
     /**
      * Starts the GeoLocation listening service.
@@ -1152,14 +1156,14 @@ declare module "FuseJS/GeoLocation" {
      *
      * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
      */
-    function startListening(minimumReportInterval: any, desiredAccuracy: any): any;
+    function startListening(minimumReportInterval: number, desiredAccuracy: number): void;
 
     /**
      * Stops the GeoLocation listening service.
      *
      * See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
      */
-    function stopListening(): any;
+    function stopListening(): void;
 
 }
 
@@ -1203,7 +1207,7 @@ declare module "FuseJS/ImageTools" {
      *     ImageTools.getBase64FromImage(image)
      *         .then(function(base64Image) { console.log("The base64 encoded image is \"" + base64Image + "\""); });
      */
-    function getBase64FromImage(image: any): any;
+    function getBase64FromImage(image: any): Promise<string>;
 
     /**
      * Retrieves the underlying image data for an image as an ArrayBuffer.
@@ -1215,7 +1219,7 @@ declare module "FuseJS/ImageTools" {
      *     ImageTools.getBufferFromImage(image)
      *         .then(function(buf) { console.log("Image contains " + buf.byteLength + " bytes"); });
      */
-    function getBufferFromImage(image: any): any;
+    function getBufferFromImage(image: any): Promise<ArrayBuffer>;
 
     /**
      * Crops the supplied `image`, and returns a Promise of the transformed Image.
@@ -1241,7 +1245,7 @@ declare module "FuseJS/ImageTools" {
      *     ImageTools.crop(originalImage, options)
      *         .then(function(newImage) { console.log("Path of cropped image is " + newImage.path); });
      */
-    function crop(image: any, options: any): any;
+    function crop(image: any, options: any): Promise<any>;
 
     /**
      * Takes base64 string encoded image data and returns a Promise of an Image.
@@ -1255,7 +1259,7 @@ declare module "FuseJS/ImageTools" {
      *             console.log("Scratch path of image is " + image.path);
      *         });
      */
-    function getImageFromBase64(base64: any): any;
+    function getImageFromBase64(base64: string): Promise<any>;
 
     /**
      * Creates a new temporary image file from an ArrayBuffer of image data.
@@ -1266,7 +1270,7 @@ declare module "FuseJS/ImageTools" {
      *     ImageTools.getImageFromBuffer(imageData).
      *         then(function (image) { console.log("Scratch image path is: " + image.path); });
      */
-    function getImageFromBuffer(imageData: any): any;
+    function getImageFromBuffer(imageData: ArrayBuffer): Promise<any>;
 
     /**
      * Resizes an image using the options provided, and returns a Promise of the transformed Image.
@@ -1295,7 +1299,7 @@ declare module "FuseJS/ImageTools" {
      *     ImageTools.resize(originalImage, options)
      *         .then(function(newImage) { console.log("Path of resized image is " + newImage.path); });
      */
-    function resize(image: any, options: any): any;
+    function resize(image: any, options: any): Promise<any>;
 
 }
 
@@ -1429,22 +1433,22 @@ declare module "FuseJS/LocalNotifications" {
     /**
      * Dismisses all currently active notifications created by our app.
      */
-    function clearAllNotifications(): any;
+    function clearAllNotifications(): void;
 
     /**
      * Clears the badge number shown on the iOS home screen.
      */
-    function clearBadgeNumber(): any;
+    function clearBadgeNumber(): void;
 
     /**
      * Displays a notification to the user after the time specified by `secondsFromNow` has passed.
      */
-    function later(secondsFromNow: any, title: any, body: any, payload: any, sound: any, badgeNumber: any): any;
+    function later(secondsFromNow: number, title: string, body: string, payload: any, sound: boolean, badgeNumber?: any): void;
 
     /**
      * Instantly displays a notification to the user.
      */
-    function now(title: any, body: any, payload: any, sound: any, badgeNumber: any): any;
+    function now(title: string, body: string, payload: any, sound: boolean, badgeNumber?: any): void;
 
 }
 
@@ -1732,20 +1736,20 @@ declare module "FuseJS/Push" {
     /**
      * Cancels all previously shown notifications.
      */
-    function clearAllNotifications(): any;
+    function clearAllNotifications(): void;
 
     /**
      * Clears the badge number shown on the iOS home screen.
      *
      * Has no effects on other platforms.
      */
-    function clearBadgeNumber(): any;
+    function clearBadgeNumber(): void;
 
     /**
      * Registers the app with APNS. Only neccesary if APNS.RegisterOnLaunch was
      * set to false in the unoproj file.
      */
-    function register(): any;
+    function register(): void;
 
 }
 
@@ -1800,12 +1804,12 @@ declare module "FuseJS/Share" {
     /**
      * Share a file to another application by path.
      */
-    function shareFile(path: any, mimetype: any, description: any): any;
+    function shareFile(path: string, mimetype: string, description: string): void;
 
     /**
      * Share raw text to another application.
      */
-    function shareText(text: any, description: any): any;
+    function shareText(text: string, description: string): void;
 
 }
 
@@ -1832,7 +1836,7 @@ declare module "FuseJS/Storage" {
      *
      * > Warning: This call will block until the operation is finished.
      */
-    function deleteSync(filename: any): any;
+    function deleteSync(filename: string): boolean;
 
     /**
      * Synchrounously reads data from a file inside the application folder.
@@ -1844,7 +1848,7 @@ declare module "FuseJS/Storage" {
      *
      * > Warning: This call will block until the operation is finished. Use read() if you are reading large amounts of data.
      */
-    function readSync(filename: any): any;
+    function readSync(filename: string): string;
 
     /**
      * Asynchronously reads a file and returns a promise of its contents.
@@ -1858,7 +1862,7 @@ declare module "FuseJS/Storage" {
      *             console.log(error);
      *         });
      */
-    function read(filename: any): any;
+    function read(filename: string): Promise<string>;
 
     /**
      * Synchrounously writes data to a file inside the application folder.
@@ -1875,7 +1879,7 @@ declare module "FuseJS/Storage" {
      *
      * > Warning: This call will block until the operation is finished. Use write() if you are writing large amounts of data.
      */
-    function writeSync(filename: any, contents: any): any;
+    function writeSync(filename: string, contents: string): boolean;
 
     /**
      * Asynchronously writes to a file.
@@ -1892,7 +1896,7 @@ declare module "FuseJS/Storage" {
      *             }
      *         });
      */
-    function write(filename: any, contents: any): any;
+    function write(filename: string, contents: string): Promise<boolean>;
 
 }
 
@@ -1909,7 +1913,7 @@ declare module "FuseJS/Storage" {
  *     vibration.vibrate(0.8);
  */
 declare module "FuseJS/Vibration" {
-    function vibrate(seconds: any): any;
+    function vibrate(seconds: number): void;
 
 }
 
@@ -1927,6 +1931,7 @@ declare module "FuseJS/Vibration" {
  *     </JavaScript>
  */
 declare module "FuseJS/VideoTools" {
+    function copyVideoToCameraRoll(somePath: string): void;
 }
 
 /**
@@ -1952,7 +1957,7 @@ declare module "FuseJS/Email" {
      *     var email = require('FuseJS/Email');
      *     email.compose("to@example.com", "cc@example.com", "bcc@example.com", "subject", "message");
      */
-    function compose(): any;
+    function compose(to: string, cc: string, bcc: string, subject: string, message: string): void;
 
 }
 
@@ -2002,7 +2007,7 @@ declare module "FuseJS/InterApp" {
      * and `facetime:<parameters>` launches a Facetime video call on iOS.
      * More information on supported URI schemes: [on Android](https://developer.android.com/guide/components/intents-common.html) and [on iOS](https://developer.apple.com/library/content/featuredarticles/iPhoneURLScheme_Reference/Introduction/Introduction.html).
      */
-    function launchUri(uri: any): any;
+    function launchUri(uri: string): void;
 
 }
 
@@ -2027,7 +2032,7 @@ declare module "FuseJS/Maps" {
      *     var Maps = require("FuseJS/Maps");
      *     Maps.openAt(59.9117715, 10.7400957);
      */
-    function openAt(): any;
+    function openAt(latitude: number, longitude: number): void;
 
     /**
      * Launches the map application, centered at the location found nearby the given `latitude` and `longitude`,
@@ -2038,7 +2043,7 @@ declare module "FuseJS/Maps" {
      *     var Maps = require("FuseJS/Maps");
      *     Maps.searchNear(59.9117715, 10.7400957, "Fusetools");
      */
-    function searchNear(): any;
+    function searchNear(latitude: number, longitude: number, query: string): void;
 
     /**
      * Launches the map application, centered at the location found using `query` as search criteria.
@@ -2048,7 +2053,7 @@ declare module "FuseJS/Maps" {
      *     var Maps = require("FuseJS/Maps");
      *     Maps.searchNearby("Fusetools");
      */
-    function searchNearby(): any;
+    function searchNearby(query: string): void;
 
 }
 
@@ -2072,7 +2077,7 @@ declare module "FuseJS/Phone" {
      *     var phone = require("FuseJS/Phone");
      *     phone.call("+47 123 45 678");
      */
-    function call(number: any): any;
+    function call(number: string): void;
 
 }
 
@@ -2090,6 +2095,8 @@ declare module "FuseJS/Phone" {
  *     }, 10000, true);
  */
 declare module "FuseJS/Timer" {
+    interface TimerId {}
+
     /**
      * Schedules `func` to be called after `time` milliseconds.
      *
@@ -2102,7 +2109,7 @@ declare module "FuseJS/Timer" {
      *         console.log("This will run every 10 seconds until forever");
      *     }, 10000, true);
      */
-    function create(func: any, time: any, repeat: any): any;
+    function create(func: () => void, time: number, repeat: boolean): TimerId;
 
     /**
      * Deletes/unschedules a running timer.
@@ -2122,7 +2129,7 @@ declare module "FuseJS/Timer" {
      * }, 2000, true);
      * ```
      */
-    function delete(timerId: any): any;
+    function delete(timerId: TimerId): void;
 
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "Source/build/*",
+    "index.d.ts",
     ".unoconfig"
   ],
   "repository": {

--- a/tools/generator-typescript/.gitignore
+++ b/tools/generator-typescript/.gitignore
@@ -1,0 +1,4 @@
+.vs/
+bin/
+obj/
+packages/

--- a/tools/generator-typescript/App.config
+++ b/tools/generator-typescript/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/tools/generator-typescript/Program.cs
+++ b/tools/generator-typescript/Program.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+class ScriptEntity
+{
+    public string Name;
+    public string Documentation;
+}
+
+class ScriptMethod : ScriptEntity
+{
+    public readonly List<string> Parameters = new List<string>();
+}
+
+class ScriptProperty : ScriptEntity
+{
+}
+
+class ScriptEvent : ScriptEntity
+{
+}
+
+class ScriptModule : ScriptEntity
+{
+    public readonly List<ScriptEvent> Events = new List<ScriptEvent>();
+    public readonly List<ScriptProperty> Properties = new List<ScriptProperty>();
+    public readonly List<ScriptMethod> Methods = new List<ScriptMethod>();
+}
+
+class Program
+{
+    static readonly Dictionary<string, ScriptModule> Modules = new Dictionary<string, ScriptModule>();
+
+    static ScriptModule GetModule(string name)
+    {
+        if (Modules.ContainsKey(name))
+            return Modules[name];
+
+        var module = new ScriptModule {Name = name};
+        Modules[name] = module;
+        return module;
+    }
+
+    static void Parse(string value)
+    {
+        var json = JsonConvert.DeserializeObject<JToken>(value);
+        var comments = json.FindTokens("comment");
+        ScriptModule module = null;
+
+        foreach (var comment in comments)
+        {
+            var attributes = comment["attributes"] as JObject;
+            if (attributes == null)
+                continue;
+
+            var brief = (comment["brief"] ?? "").ToString();
+            var full = (comment["full"] ?? "").ToString();
+
+            if (attributes.ContainsKey("scriptModule"))
+            {
+                var scriptModule = attributes["scriptModule"];
+                var name = scriptModule.ToString();
+
+                if (!name.Contains('/'))
+                    name = "FuseJS/" + name;
+
+                module = GetModule(name);
+                module.Documentation = full;
+            }
+
+            if (attributes.ContainsKey("scriptMethod"))
+            {
+                var scriptMethod = attributes["scriptMethod"];
+                var result = new ScriptMethod {Name = scriptMethod["name"].ToString(), Documentation = full};
+                module.Methods.Add(result);
+
+                foreach (var parameter in scriptMethod["parameters"])
+                    result.Parameters.Add(parameter.ToString());
+            }
+
+            if (attributes.ContainsKey("scriptProperty"))
+            {
+                var scriptProperty = attributes["scriptProperty"];
+                var result = new ScriptProperty {Name = scriptProperty.ToString(), Documentation = full};
+
+                if (result.Name.StartsWith("("))
+                    continue;
+
+                module.Properties.Add(result);
+            }
+
+            if (attributes.ContainsKey("scriptEvent"))
+            {
+                var scriptEvent = attributes["scriptEvent"];
+                var result = new ScriptEvent {Name = scriptEvent.ToString(), Documentation = brief};
+                module.Events.Add(result);
+            }
+        }
+    }
+
+    // Should follow https://github.com/Microsoft/tsdoc
+    static void WriteDocumentation(string comment, string indent = "")
+    {
+        if (string.IsNullOrEmpty(comment))
+            return;
+
+        Console.WriteLine(indent + "/**");
+
+        foreach (var line in comment.Trim('*').Trim().Split(new[] {"\r\n", "\r", "\n"}, StringSplitOptions.None))
+            if (!string.IsNullOrWhiteSpace(line))
+                Console.WriteLine(indent + " * " + line.Replace("\t", "    "));
+            else
+                Console.WriteLine(indent + " *");
+
+        Console.WriteLine(indent + " */");
+    }
+
+    static int Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("Usage: generator-typescript <path-to-api-docs>");
+            return 1;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(args[0], "*.json", SearchOption.AllDirectories))
+        {
+            var value = File.ReadAllText(file);
+            if (!value.Contains("\"scriptModule\":"))
+                continue;
+
+            Parse(value);
+        }
+
+        // We want LF newlines in our output.
+        Console.Out.NewLine = "\n";
+
+        foreach (var module in Modules.Values)
+        {
+            WriteDocumentation(module.Documentation);
+            Console.WriteLine($"declare module \"{module.Name}\" {{");
+
+            foreach (var property in module.Properties)
+            {
+                WriteDocumentation(property.Documentation, "    ");
+                Console.WriteLine($"    const {property.Name}: any;");
+                Console.WriteLine();
+            }
+
+            if (module.Events.Count > 0)
+            {
+                Console.Write("    type Event = ");
+
+                var first = true;
+                foreach (var e in module.Events)
+                {
+                    if (!first)
+                    {
+                        Console.WriteLine(" |");
+                        Console.Write("                 ");
+                    }
+
+                    Console.Write($"\"{e.Name}\"");
+                    first = false;
+                }
+
+                Console.WriteLine(";");
+                Console.WriteLine();
+
+                var comment = "Registers a function to be called when one of the following events occur.\n\n";
+
+                foreach (var e in module.Events)
+                    comment += $"* `\"{e.Name}\"` - {e.Documentation}\n";
+
+                WriteDocumentation(comment, "    ");
+                Console.WriteLine($"    function on(event: Event, callback: () => void): void;");
+                Console.WriteLine();
+            }
+
+            foreach (var method in module.Methods)
+            {
+                WriteDocumentation(method.Documentation, "    ");
+                Console.Write($"    function {method.Name}(");
+
+                var first = true;
+                foreach (var parameter in method.Parameters)
+                {
+                    if (string.IsNullOrEmpty(parameter))
+                        continue;
+
+                    if (!first)
+                        Console.Write(", ");
+
+                    Console.Write($"{parameter.Trim('[', ']')}: any");
+                    first = false;
+                }
+
+                Console.WriteLine($"): any;");
+                Console.WriteLine();
+            }
+
+            Console.WriteLine("}");
+            Console.WriteLine();
+        }
+
+        return 0;
+    }
+}
+
+// Taken from https://stackoverflow.com/questions/19645501/searching-for-a-specific-jtoken-by-name-in-a-jobject-hierarchy
+public static class JsonExtensions
+{
+    public static List<JToken> FindTokens(this JToken containerToken, string name)
+    {
+        List<JToken> matches = new List<JToken>();
+        FindTokens(containerToken, name, matches);
+        return matches;
+    }
+
+    private static void FindTokens(JToken containerToken, string name, List<JToken> matches)
+    {
+        if (containerToken.Type == JTokenType.Object)
+        {
+            foreach (JProperty child in containerToken.Children<JProperty>())
+            {
+                if (child.Name == name)
+                {
+                    matches.Add(child.Value);
+                }
+                FindTokens(child.Value, name, matches);
+            }
+        }
+        else if (containerToken.Type == JTokenType.Array)
+        {
+            foreach (JToken child in containerToken.Children())
+            {
+                FindTokens(child, name, matches);
+            }
+        }
+    }
+}

--- a/tools/generator-typescript/Properties/AssemblyInfo.cs
+++ b/tools/generator-typescript/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("generator-typescript")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("generator-typescript")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e5e71e65-fb18-49c4-a5e2-524b49441f94")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/generator-typescript/README.md
+++ b/tools/generator-typescript/README.md
@@ -1,0 +1,8 @@
+# TypeScript Definitions generator
+
+This program generates a TypeScript Definitions file based on the JSON files
+found in `api-docs/`, located in the [docs-repo](https://github.com/fuse-open/docs).
+
+Usage example:
+
+    generator-typescript \path\to\api-docs > index.d.ts

--- a/tools/generator-typescript/generator-typescript.csproj
+++ b/tools/generator-typescript/generator-typescript.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E5E71E65-FB18-49C4-A5E2-524B49441F94}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>generator_typescript</RootNamespace>
+    <AssemblyName>generator-typescript</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tools/generator-typescript/generator-typescript.sln
+++ b/tools/generator-typescript/generator-typescript.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-typescript", "generator-typescript.csproj", "{E5E71E65-FB18-49C4-A5E2-524B49441F94}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E5E71E65-FB18-49C4-A5E2-524B49441F94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5E71E65-FB18-49C4-A5E2-524B49441F94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5E71E65-FB18-49C4-A5E2-524B49441F94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5E71E65-FB18-49C4-A5E2-524B49441F94}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8C165C00-482C-461F-A24F-B0C56299A8D5}
+	EndGlobalSection
+EndGlobal

--- a/tools/generator-typescript/packages.config
+++ b/tools/generator-typescript/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
I've added the generator program and updated doc-comment formatting to match [TSDoc](https://github.com/Microsoft/tsdoc), otherwise this PR is identical to #1261 (which was accidentally closed and can't be reopened).

> This adds a Definitions file for TypeScript, helpful for code-completion and as documentation.
>
> This file is automatically picked up by TypeScript editors when Fuselibs is installed to `node_modules/` via `npm install` or `npm link`. Tested in Visual Studio Code.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
