### PR TITLE
Add disk cache functionality to image

### DIFF
--- a/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
+++ b/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
@@ -2,6 +2,7 @@ using Uno;
 using Uno.UX;
 
 using Fuse.Scripting;
+using Fuse.Resources;
 
 namespace Fuse.Controls
 {
@@ -11,7 +12,8 @@ namespace Fuse.Controls
 		{
 			ScriptClass.Register(typeof(Image),
 				new ScriptMethod<Image>("reload", reload),
-				new ScriptMethod<Image>("retry", retry));
+				new ScriptMethod<Image>("retry", retry),
+				new ScriptMethod<Image>("clearCache", clearCache));
 		}
 		
 		/**
@@ -36,6 +38,22 @@ namespace Fuse.Controls
 			var src = img.Source;
 			if (src != null && src.State == Fuse.Resources.ImageSourceState.Failed)
 				src.Reload();
+		}
+
+		/**
+			Clear the image cache from disk. only applicable if image source is from Url
+
+			@scriptmethod clearCache( )
+		*/
+		static void clearCache(Image img)
+		{
+			var src = img.Source;
+			if (src != null)
+			{
+				var http = src as HttpImageSource;
+				if (http != null)
+					http.ClearCache();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add disk cache functionality to the image so that the next time we display an image it will no longer be downloaded from the network.

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests