### PR TITLE
Android: add fat builds (64-bit support)

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/V8/V8.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8.stuff
@@ -1,3 +1,3 @@
 if ANDROID {
-    android: "https://www.nuget.org/api/v2/package/v8-static-armv7/6.9.427.23"
+    android: "https://www.nuget.org/api/v2/package/v8-android-static/6.9.427.23"
 }

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -8,12 +8,12 @@
 	<!-- Build V8Simple on Android, and link static V8 -->
 	<CopyFile Condition="ANDROID" SourceFile="include/V8Simple.cpp" />
 	<Require Condition="ANDROID" IncludeDirectory="@('android/include':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_init.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_initializers.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_libbase.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_libplatform.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_libsampler.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_snapshot.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_init.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_initializers.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_libbase.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_libplatform.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_libsampler.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_snapshot.a':Path)" />
 	<!-- Must be last library to avoid linker error -->
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/libv8_base.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_base.a':Path)" />
 </Extensions>

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -8,12 +8,12 @@
 	<!-- Build V8Simple on Android, and link static V8 -->
 	<CopyFile Condition="ANDROID" SourceFile="include/V8Simple.cpp" />
 	<Require Condition="ANDROID" IncludeDirectory="@('android/include':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_init.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_initializers.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_libbase.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_libplatform.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_libsampler.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_snapshot.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_init.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_initializers.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_libbase.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_libplatform.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_libsampler.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_snapshot.a':Path)" />
 	<!-- Must be last library to avoid linker error -->
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/@(ABI)/libv8_base.a':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_base.a':Path)" />
 </Extensions>

--- a/Source/Fuse.Text/Implementation/Harfbuzz.uno
+++ b/Source/Fuse.Text/Implementation/Harfbuzz.uno
@@ -9,13 +9,14 @@ namespace Fuse.Text.Implementation
 	[Require("Source.Include", "hb-ft-cached.h")]
 	[Require("Source.Include", "ft2build.h")]
 	[Require("Source.Declaration", "#include FT_ADVANCES_H")]
-	[extern(APPLE || ANDROID) Require("IncludeDirectory", "@('../harfbuzz/include':Path)")]
+	[extern(APPLE) Require("IncludeDirectory", "@('../harfbuzz/include':Path)")]
+	[extern(ANDROID) Require("IncludeDirectory", "@('../harfbuzz/lib/Android/include':Path)")] // Android use a newer version of Harfbuzz
 	[extern(WIN32) Require("IncludeDirectory", "@('../harfbuzz/lib/Windows/include':Path)")] // Windows use a newer version of Harfbuzz
 	[extern(iOS) Require("Source.Include", "harfbuzz/hb-coretext.h")]
 	[extern(iOS) Require("LinkDirectory", "@('../harfbuzz/lib/iOS':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("LinkDirectory", "@('../harfbuzz/lib/OSX':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("Xcode.Framework", "CoreText")]
-	[extern(Android) Require("StaticLibrary", "@('../harfbuzz/lib/Android/libharfbuzz.a':Path)")]
+	[extern(Android) Require("StaticLibrary", "@('../harfbuzz/lib/Android/lib/@(ABI)/libharfbuzz.a':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_WINDOWS) Require("LinkDirectory", "@('../harfbuzz/lib/Windows':Path)")]
 	[extern(!Android) Require("LinkLibrary", "harfbuzz")]
 	[TargetSpecificImplementation]

--- a/Source/Fuse.Text/Implementation/Harfbuzz.uno
+++ b/Source/Fuse.Text/Implementation/Harfbuzz.uno
@@ -16,7 +16,7 @@ namespace Fuse.Text.Implementation
 	[extern(iOS) Require("LinkDirectory", "@('../harfbuzz/lib/iOS':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("LinkDirectory", "@('../harfbuzz/lib/OSX':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_MAC) Require("Xcode.Framework", "CoreText")]
-	[extern(Android) Require("StaticLibrary", "@('../harfbuzz/lib/Android/lib/@(ABI)/libharfbuzz.a':Path)")]
+	[extern(Android) Require("StaticLibrary", "@('../harfbuzz/lib/Android/lib/${ANDROID_ABI}/libharfbuzz.a':Path)")]
 	[extern((PInvoke || NATIVE) && HOST_WINDOWS) Require("LinkDirectory", "@('../harfbuzz/lib/Windows':Path)")]
 	[extern(!Android) Require("LinkLibrary", "harfbuzz")]
 	[TargetSpecificImplementation]

--- a/Source/Fuse.Text/harfbuzz/lib/Android.stuff
+++ b/Source/Fuse.Text/harfbuzz/lib/Android.stuff
@@ -1,3 +1,3 @@
 if ANDROID {
-/* 0.21MB */ Android: "https://www.nuget.org/api/v2/package/harfbuzz-android-static-armv7/1.2.4"
+/* 0.21MB */ Android: "https://www.nuget.org/api/v2/package/harfbuzz-android-static/1.8.1"
 }


### PR DESCRIPTION
This replaces Android packages of Harfbuzz and V8, and includes code for `armeabi-v7a`, `arm64-v8a`, `x86` and `x86_64`*.

* V8 is not currently available for `x86_64`.

Related: https://github.com/fuse-open/uno/issues/154

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
