### PR TITLE
Add Value property to TransitionState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+### Fuse.Triggers.Actions.TransitionState
+- Added `Value` property on `TransitionState`.
 
 # 1.12
 

--- a/Source/Fuse.Triggers/Actions/StateTransition.uno
+++ b/Source/Fuse.Triggers/Actions/StateTransition.uno
@@ -7,30 +7,64 @@ namespace Fuse.Triggers.Actions
 		Next,
 	}
 
+
 	/**
 		@mount Trigger Actions
+
+		An action that controls state of a @StateGroup.
+
+		## Example
+		The following example displays a red panel that will turn its color in green when clicked.
+
+			<Panel ux:Name="thePanel" Width="100" Height="100">
+				<StateGroup ux:Name="stateGroup">
+					<State ux:Name="redState">
+						<Change thePanel.Color="#f00" Duration="0.2"/>
+					</State>
+					<State ux:Name="greenState">
+						<Change thePanel.Color="#0f0" Duration="0.2"/>
+					</State>
+				</StateGroup>
+
+				<Clicked>
+					<TransitionState Value="greenState" Target="stateGroup" />
+				</Clicked>
+			</Panel>
 	*/
 	public class TransitionState : TriggerAction
 	{
+		/** StateGroup to be be transitioned **/
 		public StateGroup Target { get; set; }
-	
+
 		public TransitionStateType Type { get; set; }
-		
+
+		/** Explicit target state to transition to  **/
+		public State Value { get; set; }
+
 		protected override void Perform(Node target)
 		{
 			var t = Target;
+			var s = Value;
+
 			if (t == null)
 			{
 				Fuse.Diagnostics.UserError( "Missing `Target`", this );
 				return;
 			}
-			
+
+			if (s != null) {
+				t.Goto(s);
+				return;
+			}
+
 			switch (Type)
 			{
 				case TransitionStateType.Next:
 					t.GotoNextState();
-					break;
+					return;
 			}
+
+			Fuse.Diagnostics.UserWarning( "Provide `Value` or `Type`", this );
 		}
 	}
 }

--- a/Source/Fuse.Triggers/Tests/StateGroup.Test.uno
+++ b/Source/Fuse.Triggers/Tests/StateGroup.Test.uno
@@ -145,5 +145,19 @@ namespace Fuse.Triggers.Test
 				Assert.AreEqual(p.s2,p.sg.Active);
 			}
 		}
+
+		[Test]
+		public void TransitionStateValue()
+		{
+			var p = new UX.StateGroup.TransitionStateValue();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(p.s1,p.sg.Active);
+				
+				p.t1.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual(p.s3,p.sg.Active);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Triggers/Tests/UX/StateGroup.TransitionStateValue.ux
+++ b/Source/Fuse.Triggers/Tests/UX/StateGroup.TransitionStateValue.ux
@@ -1,0 +1,11 @@
+<Panel ux:Class="UX.StateGroup.TransitionStateValue">
+	<StateGroup ux:Name="sg">
+		<State ux:Name="s1"/>
+		<State ux:Name="s2"/>
+		<State ux:Name="s3"/>
+	</StateGroup>
+
+	<Timeline ux:Name="t1">
+		<TransitionState Target="sg" Value="s3"/>
+	</Timeline>
+</Panel>


### PR DESCRIPTION
Added `Value` property on `TransitionState` to be able to transition directly to defined state

This PR contains:
- [X] Changelog
- [X] Documentation
- [X] Tests
