### PR TITLE
Fuse.Charting: drop experimental attributes

### DIFF
--- a/Source/Fuse.Animations/Attract.uno
+++ b/Source/Fuse.Animations/Attract.uno
@@ -14,7 +14,6 @@ namespace Fuse.Animations
 		A single `AttractorConfig` can be used for multiple `attract` expressions.
 		
 		@see @Attract
-		@experimental
 	*/
 	public class AttractorConfig : DestinationMotionConfig
 	{

--- a/Source/Fuse.Charting/DataSeries.uno
+++ b/Source/Fuse.Charting/DataSeries.uno
@@ -15,8 +15,6 @@ namespace Fuse.Charting
 	
 	/**
 		Provides a source of data for plotting.
-		
-		@experimental
 	*/
 	public class DataSeries : PropertyObject, Fuse.Reactive.IObserver
 	{

--- a/Source/Fuse.Charting/Plot.uno
+++ b/Source/Fuse.Charting/Plot.uno
@@ -10,7 +10,6 @@ namespace Fuse.Charting
 		A panel that contains a chart.
 		
 		@see Docs/plot.md
-		@experimental
 	*/
 	public partial class Plot : Panel
 	{

--- a/Source/Fuse.Charting/PlotAxis.uno
+++ b/Source/Fuse.Charting/PlotAxis.uno
@@ -183,9 +183,6 @@ namespace Fuse.Charting
 					</c:Plot>
 				</Panel>
 			</Panel>
-
-		
-		@experimental
 	*/
 	public class PlotAxis : Panel
 	{

--- a/Source/Fuse.Charting/PlotAxisLayout.uno
+++ b/Source/Fuse.Charting/PlotAxisLayout.uno
@@ -24,7 +24,6 @@ namespace Fuse.Charting
 		Consider using @PlotAxis instead to provide labels for the plot. It will use this layout.
 		
 		@advanced
-		@experimental
 	*/
 	public class PlotAxisLayout : Fuse.Layouts.Layout
 	{

--- a/Source/Fuse.Charting/PlotBar.uno
+++ b/Source/Fuse.Charting/PlotBar.uno
@@ -52,8 +52,6 @@ namespace Fuse.Charting
 					</c:Plot>
 				</Panel>
 			</Panel>
-
-		@experimental
 	*/
 	public class PlotBar : PlotElement
 	{

--- a/Source/Fuse.Charting/PlotCurvePoint.uno
+++ b/Source/Fuse.Charting/PlotCurvePoint.uno
@@ -40,8 +40,6 @@ namespace Fuse.Charting
 					</c:Plot>
 				</Panel>
 			</Panel>
-		
-		@experimental
 	*/
 	public class PlotCurvePoint : CurvePoint, IPlotDataItemListener<PlotDataPoint>
 	{

--- a/Source/Fuse.Charting/PlotData.uno
+++ b/Source/Fuse.Charting/PlotData.uno
@@ -18,8 +18,6 @@ namespace Fuse.Charting
 					<c:PlotCurvePoint/>
 				</c:PlotData>
 			</Curve>
-		
-		@experimental
 	*/
 	public class PlotData : Instantiator, IPlotDataItemProvider
 	{

--- a/Source/Fuse.Charting/PlotElement.uno
+++ b/Source/Fuse.Charting/PlotElement.uno
@@ -8,8 +8,6 @@ namespace Fuse.Charting
 {
 	/**
 		Common base for plot positioned elements.
-		
-		@experimental
 	*/
 	abstract public class PlotElement : Panel, IPlotDataItemListener<PlotDataPoint>
 	{

--- a/Source/Fuse.Charting/PlotExpression.uno
+++ b/Source/Fuse.Charting/PlotExpression.uno
@@ -13,8 +13,6 @@ namespace Fuse.Charting
 		The prefix `axis.` is used within a @PlotAxis to access the values of axis.
 		
 		Unprefixed values access values in the @Plot
-		
-		@experimental
 	*/
 	[UXUnaryOperator("Plot")]
 	public sealed class PlotExpression : Fuse.Reactive.Expression

--- a/Source/Fuse.Charting/PlotPoint.uno
+++ b/Source/Fuse.Charting/PlotPoint.uno
@@ -155,8 +155,6 @@ namespace Fuse.Charting
 		This panel has a default of `Anchor="50%,50%"`.  This can be changed with `PointAnchor`
 		
 		This panel does not have any default size.
-		
-		@experimental
 	*/
 	public class PlotPoint : PlotElement
 	{

--- a/Source/Fuse.Charting/PlotTicks.uno
+++ b/Source/Fuse.Charting/PlotTicks.uno
@@ -58,8 +58,6 @@ namespace Fuse.Charting
 			</Panel>
 
 		`AxisLine` indicates a line across the entire access should be drawn at this offset. In this example it's the top of the ticks, making this suitable for the bottom of a chart.
-
-		@experimental
 	*/
 	public class PlotTicks : Shape
 	{


### PR DESCRIPTION
This should remove the following notice from generated pages at https://fuseopen.com/docs.

    This entity is experimental and might be changed or removed in a future release.

Because Fuse.Animations.AttractorConfig is commonly used in Fuse.Charting code, we
also drop the experimental attribute from this class.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
