### PR TITLE
Fuse.Platform: drop unused method on iOS

### DIFF
--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -218,12 +218,6 @@ namespace Fuse.Platform
 			set { Uno.Platform.iOS.Application.SetRootView(value); }
 		}
 
-		[Foreign(Language.ObjC)]
-		static void SetAsRootView(ObjC.Object view)
-		@{
-
-		@}
-
 		static void OnWillResize()
 		{
 			if (MarginsChanged != null)


### PR DESCRIPTION
This method is private, not used and not implemented. Let's remove it.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
