### PR TITLE
iOS 13 SystemFont Changes + Previous System Font Issues

### DIFF
--- a/Source/Fuse.Common/Font.uno
+++ b/Source/Fuse.Common/Font.uno
@@ -89,6 +89,9 @@ namespace Fuse
 		}
 
 		[UXGlobalResource]
+		extern (Android) public static readonly Font UltraLight = new SystemFont("sans-serif-thin", SystemFont.Style.Normal, SystemFont.Weight.Thin);
+
+		[UXGlobalResource]
 		extern (Android) public static readonly Font Thin = new SystemFont("sans-serif-thin", SystemFont.Style.Normal, SystemFont.Weight.Thin);
 
 		[UXGlobalResource]
@@ -101,7 +104,19 @@ namespace Fuse
 		extern (Android) public static readonly Font Medium = new SystemFont("sans-serif", SystemFont.Style.Normal, SystemFont.Weight.Medium);
 
 		[UXGlobalResource]
+		extern (Android) public static readonly Font Semibold = new SystemFont("sans-serif", SystemFont.Style.Normal, SystemFont.Weight.Bold);
+
+		[UXGlobalResource]
 		extern (Android) public static readonly Font Bold = new SystemFont("sans-serif", SystemFont.Style.Normal, SystemFont.Weight.Bold);
+
+		[UXGlobalResource]
+		extern (Android) public static readonly Font Heavy = new SystemFont("sans-serif", SystemFont.Style.Normal, SystemFont.Weight.Bold);
+
+		[UXGlobalResource]
+		extern (Android) public static readonly Font Black = new SystemFont("sans-serif", SystemFont.Style.Normal, SystemFont.Weight.Bold);
+
+		[UXGlobalResource]
+		extern (Android) public static readonly Font UltraLightItalic = new SystemFont("sans-serif-thin", SystemFont.Style.Italic, SystemFont.Weight.Thin);
 
 		[UXGlobalResource]
 		extern (Android) public static readonly Font ThinItalic = new SystemFont("sans-serif-thin", SystemFont.Style.Italic, SystemFont.Weight.Thin);
@@ -116,8 +131,21 @@ namespace Fuse
 		extern (Android) public static readonly Font MediumItalic = new SystemFont("sans-serif", SystemFont.Style.Italic, SystemFont.Weight.Medium);
 
 		[UXGlobalResource]
+		extern (Android) public static readonly Font SemiboldItalic = new SystemFont("sans-serif", SystemFont.Style.Italic, SystemFont.Weight.Bold);
+
+		[UXGlobalResource]
 		extern (Android) public static readonly Font BoldItalic = new SystemFont("sans-serif", SystemFont.Style.Italic, SystemFont.Weight.Bold);
 
+		[UXGlobalResource]
+		extern (Android) public static readonly Font HeavyItalic = new SystemFont("sans-serif", SystemFont.Style.Italic, SystemFont.Weight.Bold);
+
+		[UXGlobalResource]
+		extern (Android) public static readonly Font BlackItalic = new SystemFont("sans-serif", SystemFont.Style.Italic, SystemFont.Weight.Bold);
+
+
+
+		[UXGlobalResource]
+		extern (iOS) public static readonly Font UltraLight = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.UltraLight);
 
 		[UXGlobalResource]
 		extern (iOS) public static readonly Font Thin = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.Thin);
@@ -129,16 +157,31 @@ namespace Fuse
 		extern (iOS) public static readonly Font Regular = new SystemFont(Internal.iOSSystemFont.DefaultFontName);
 
 		[UXGlobalResource]
+		extern (iOS) public static readonly Font Normal = new SystemFont(Internal.iOSSystemFont.DefaultFontName);
+
+		[UXGlobalResource]
 		extern (iOS) public static readonly Font Medium = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.Medium);
 
 		[UXGlobalResource]
+		extern (iOS) public static readonly Font Semibold = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.Semibold);
+
+		[UXGlobalResource]
 		extern (iOS) public static readonly Font Bold = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.Bold);
+		
+		[UXGlobalResource]
+		extern (iOS) public static readonly Font Heavy = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.Heavy);
+		
+		[UXGlobalResource]
+		extern (iOS) public static readonly Font Black = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Normal, SystemFont.Weight.Black);
+		
+		[UXGlobalResource]
+		extern (iOS) public static readonly Font UltraLightItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.UltraLight);
 
 		[UXGlobalResource]
-		extern (iOS) public static readonly Font ThinItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Light); // Swapped intentionally
+		extern (iOS) public static readonly Font ThinItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Thin);
 
 		[UXGlobalResource]
-		extern (iOS) public static readonly Font LightItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Thin); // Swapped intentionally
+		extern (iOS) public static readonly Font LightItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Light);
 
 		[UXGlobalResource]
 		extern (iOS) public static readonly Font Italic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic);
@@ -147,8 +190,23 @@ namespace Fuse
 		extern (iOS) public static readonly Font MediumItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Medium);
 
 		[UXGlobalResource]
+		extern (iOS) public static readonly Font SemiboldItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Semibold);
+
+		[UXGlobalResource]
 		extern (iOS) public static readonly Font BoldItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Bold);
 
+		[UXGlobalResource]
+		extern (iOS) public static readonly Font HeavyItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Heavy);
+
+		[UXGlobalResource]
+		extern (iOS) public static readonly Font BlackItalic = new SystemFont(Internal.iOSSystemFont.DefaultFontName, SystemFont.Style.Italic, SystemFont.Weight.Black);
+
+
+
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's thin weight typeface. */
+		extern (!iOS && !Android) public static readonly Font UltraLight = new Font(import("Internal/DesktopFonts/Roboto-Thin.ttf"));
 
 		[UXGlobalResource]
 		/** The default font of the system, in it's thin weight typeface. */
@@ -168,8 +226,23 @@ namespace Fuse
 
 		[UXGlobalResource]
 		/** The default font of the system, in it's bold typeface. */
+		extern (!iOS && !Android) public static readonly Font Semibold = new Font(import("Internal/DesktopFonts/Roboto-Bold.ttf"));
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's bold typeface. */
 		extern (!iOS && !Android) public static readonly Font Bold = new Font(import("Internal/DesktopFonts/Roboto-Bold.ttf"));
 
+		[UXGlobalResource]
+		/** The default font of the system, in it's bold typeface. */
+		extern (!iOS && !Android) public static readonly Font Heavy = new Font(import("Internal/DesktopFonts/Roboto-Bold.ttf"));
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's bold typeface. */
+		extern (!iOS && !Android) public static readonly Font Black = new Font(import("Internal/DesktopFonts/Roboto-Bold.ttf"));
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's thin weight typeface. */
+		extern (!iOS && !Android) public static readonly Font UltraLightItalic = new Font(import("Internal/DesktopFonts/Roboto-ThinItalic.ttf"));
 
 		[UXGlobalResource]
 		/** The default font of the system, in it's thin weight typeface. */
@@ -189,6 +262,18 @@ namespace Fuse
 
 		[UXGlobalResource]
 		/** The default font of the system, in it's bold and italic typeface. */
+		extern (!iOS && !Android) public static readonly Font SemiboldItalic = new Font(import("Internal/DesktopFonts/Roboto-BoldItalic.ttf"));
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's bold and italic typeface. */
 		extern (!iOS && !Android) public static readonly Font BoldItalic = new Font(import("Internal/DesktopFonts/Roboto-BoldItalic.ttf"));
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's bold and italic typeface. */
+		extern (!iOS && !Android) public static readonly Font HeavyItalic = new Font(import("Internal/DesktopFonts/Roboto-BoldItalic.ttf"));
+
+		[UXGlobalResource]
+		/** The default font of the system, in it's bold and italic typeface. */
+		extern (!iOS && !Android) public static readonly Font BlackItalic = new Font(import("Internal/DesktopFonts/Roboto-BoldItalic.ttf"));
 	}
 }

--- a/Source/Fuse.Common/Internal/SystemFont.uno
+++ b/Source/Fuse.Common/Internal/SystemFont.uno
@@ -11,6 +11,13 @@ namespace Fuse.Internal
 		public readonly int Index;
 		public readonly IEnumerable<string> Styles;
 
+		//iOS13+ - for default systemfont
+		extern(IOS) internal bool IsCustomFont = true;
+		extern(IOS) internal Fuse.SystemFont.Style FontStyle; //normal/italic
+		extern(IOS) internal Fuse.SystemFont.Weight FontWeight; //thin/light/regular/bold/etc
+		extern(IOS) internal Fuse.SystemFont.Design FontDesign; //default/monospaced/rounded/serif
+		extern(IOS) internal int FontSize; //12/16/etc
+
 		/** Create a `FontFaceDescriptor` that selects the face by matching the its string. */
 		public FontFaceDescriptor(FileSource fileSource, IEnumerable<string> styles)
 		{
@@ -51,6 +58,15 @@ namespace Fuse.Internal
 				hash = hash * 23 + s.GetHashCode();
 			}
 			return hash;
+		}
+
+		extern(IOS) internal void SetFontAttributes(Fuse.SystemFont.Style fontStyle, Fuse.SystemFont.Weight fontWeight, Fuse.SystemFont.Design fontDesign, int fontSize, bool isCustomFont)
+		{
+			FontStyle = fontStyle;
+			FontWeight = fontWeight;
+			FontDesign = fontDesign;
+			FontSize = fontSize;
+			IsCustomFont = isCustomFont;
 		}
 	}
 

--- a/Source/Fuse.Common/SystemFont.uno
+++ b/Source/Fuse.Common/SystemFont.uno
@@ -1,4 +1,5 @@
 using Uno.UX;
+using Uno;
 
 namespace Fuse
 {
@@ -42,16 +43,27 @@ namespace Fuse
 			Light,
 			Normal,
 			Medium,
-			SemiBold,
+			Semibold,
 			Bold,
 			Heavy,
 			Black,
+
+			[Obsolete]
+			SemiBold = Semibold
 		}
 
 		public enum Style
 		{
 			Normal,
 			Italic,
+		}
+
+		public enum Design
+		{
+			Default,
+			Monospaced,
+			Rounded,
+			Serif,
 		}
 
 		[UXConstructor]

--- a/Source/Fuse.Controls.Native/iOS/FontCache.uno
+++ b/Source/Fuse.Controls.Native/iOS/FontCache.uno
@@ -37,12 +37,26 @@ namespace Fuse.Controls.Native.iOS
 			var path = GetOptionalPath(descriptor.FileSource);
 			if (path != null)
 			{
-				var uifontdescriptor
+				if (descriptor.IsCustomFont) 
+				{
+					var uifontdescriptor
 					= iOSSystemFont.GetMatchingUIFontDescriptor(
 						path,
 						descriptor.Index,
 						descriptor.Match);
-				uifont = UIFontWithDescriptorAndSize(uifontdescriptor, size);
+					uifont = UIFontWithDescriptorAndSize(uifontdescriptor, size);
+				} 
+				else 
+				{
+					var uifontdescriptor
+					= iOSSystemFont.GetMatchingSystemFontDescriptor(
+						descriptor.FontStyle,
+						descriptor.FontWeight,
+						descriptor.FontDesign,
+						descriptor.FontSize
+					);
+					uifont = UIFontWithDescriptorAndSize(uifontdescriptor, size);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
- added iOS13 way of doing SystemFont
- fixed older system font issues with font weight/style
- added reasonable fallbacks for missing font weights for older system font way

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
