### PR TITLE
Android: upgrade V8 to v7.6.303.30

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/V8/V8.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8.stuff
@@ -1,3 +1,3 @@
 if ANDROID {
-    android: "https://www.nuget.org/api/v2/package/v8-android-static/6.9.427.23"
+    android: "https://www.nuget.org/api/v2/package/v8-android-static/7.6.303.30"
 }

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -8,12 +8,12 @@
 	<!-- Build V8Simple on Android, and link static V8 -->
 	<CopyFile Condition="ANDROID" SourceFile="include/V8Simple.cpp" />
 	<Require Condition="ANDROID" IncludeDirectory="@('android/include':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_init.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_initializers.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_libbase.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_libplatform.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_libsampler.a':Path)" />
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_snapshot.a':Path)" />
-	<!-- Must be last library to avoid linker error -->
-	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8_base.a':Path)" />
+	<Require Condition="ANDROID" IncludeDirectory="@('android/lib/${ANDROID_ABI}/include':Path)" />
+	<Require Condition="ANDROID" StaticLibrary="@('android/lib/${ANDROID_ABI}/libv8.a':Path)" />
+
+	<!-- V8 binary includes a custom-built version of STL; configure to link that version -->
+	<Require Condition="ANDROID" PreprocessorDefinition="_LIBCPP_ABI_VERSION=Cr" />
+	<Require Condition="ANDROID" PreprocessorDefinition="_LIBCPP_ABI_NAMESPACE=__Cr" />
+	<Require Condition="ANDROID" PreprocessorDefinition="_LIBCPP_ENABLE_NODISCARD" />
+	<Require Condition="ANDROID" PreprocessorDefinition="_LIBCPP_ABI_UNSTABLE" />
 </Extensions>


### PR DESCRIPTION
This version also includes binaries for x86_64, which are missing in the
current v6.9.427.23 distribution.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
