### PR TITLE
build: pass --express flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fuse-open/uno": "^1.12.2"
   },
   "scripts": {
-    "build": "uno doctor Source",
+    "build": "uno doctor Source --express",
     "prepack": "bash -c 'uno doctor Source --version=$npm_package_version --configuration=Release'",
     "test": "uno test Source --run-local",
     "android": "uno build android Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",


### PR DESCRIPTION
This will only build libraries that are actually changed, skipping
dependents.

This will make incremental builds faster when making small changes
to a few libraries.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
