### PR TITLE
Fix typo in ImageTools.crop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.ImageTools
+- Fix crop function not using height parameter
+
 ### Fuse.Alerts
 - Fix crash on iOS 13
 

--- a/Source/Fuse.ImageTools/ImageTools.uno
+++ b/Source/Fuse.ImageTools/ImageTools.uno
@@ -266,7 +266,7 @@ namespace Fuse.ImageTools
 				x = opts.ValueOrDefault<int>("x", 0);
 				y = opts.ValueOrDefault<int>("y", 0);
 				width = opts.ValueOrDefault<int>("width", 0);
-				height = opts.ValueOrDefault<int>("width", width);
+				height = opts.ValueOrDefault<int>("height", width);
 				inPlace = opts.ValueOrDefault<bool>("performInPlace", true);
 			}
 


### PR DESCRIPTION
Typo in crop function causing always square crop

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
