### PR TITLE
SVGPathParser tokenizer improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.Drawing.Surface
+- Fixed SVGPathParser to better parse minimized svg data.
+
 ### Fuse.ImageTools
 - Fix crop function not using height parameter
 

--- a/Source/Fuse.Drawing.Surface/Tests/LineParser.Test.uno
+++ b/Source/Fuse.Drawing.Surface/Tests/LineParser.Test.uno
@@ -36,6 +36,28 @@ namespace Fuse.Test
 				float2(123.3333f,126.6666f), float2(151.6666f,126.6666f) );
 		}
 		
+		
+		[Test]
+		public void PointTokenStart()
+		{
+			var list = new LineSegments();
+			LineParser.ParseSVGPath( "M10 10c0 1.1.9 2 2.2.2", list.Segments );
+			
+			Assert.AreEqual(2, list.Segments.Count);
+			Check( list.Segments[0], LineSegmentType.Move, float2(10,10) );
+			Check( list.Segments[1], LineSegmentType.BezierCurve, float2(12.2f,10.2f), 
+				float2(10f,11.1f), float2(10.9f, 12f) );
+			
+			list.Clear();
+
+			LineParser.ParseSVGPath( "M10 10c0.1.2.3.4.5.6", list.Segments );
+			
+			Assert.AreEqual(2, list.Segments.Count);
+			Check( list.Segments[0], LineSegmentType.Move, float2(10,10) );
+			Check( list.Segments[1], LineSegmentType.BezierCurve, float2(10.5f,10.6f), 
+				float2(10.1f,10.2f), float2(10.3f, 10.4f) );
+		}
+		
 		void Check( LineSegment ls, LineSegmentType type, float2 to )
 		{
 			Assert.AreEqual( type, ls.Type );


### PR DESCRIPTION
Adds support to SVGPathParser to process svg path data with serial floating points that are minimized.

I.e. following minimized svg has valid data path (in browser), but not in Fuse
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16">
    <path d="M19 6H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H5V8h14v8z "></path>
</svg>
```
The problem is curve `c0 1.1.9 2 2 2` being translated to 5 tokens instead of 6.

This PR improves SVGPathParser to properly generate tokens in these cases  (`c 0  1.1 .9 2 2 2`)

This PR contains:
- [x] Changelog
- [ ] Documentation
- [x] Tests
