### PR TITLE
travis: unset variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - npm run build
   - export XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
   - uno build ios Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
-  - export XCODE_XCCONFIG_FILE=
+  - unset XCODE_XCCONFIG_FILE
   - uno test native --timeout=30 Source/AllTests.unoproj
 
 after_failure:


### PR DESCRIPTION
Unsetting instead of assigning empty string avoid getting the following
warning in the build log.

    Ignoring configuration file '(null)' because it could not be loaded.
	    Reason: File could not be parsed due to preprocessing errors:

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
