### PR TITLE
Fuse.Models: allow unsetting Model

### DIFF
--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -70,7 +70,7 @@ namespace Fuse.Models
 			v.RemoveAllChildren<ModelJavaScript>();
 			
 			//avoid creating without the NameTable as unfortunately UX will set the Model prior to the NameTable
-			if (md.NameTable == null || md.ModulePath == null)
+			if (md.NameTable == null || string.IsNullOrEmpty(md.ModulePath))
 				return;
 			
 			v.Children.Add(new ModelJavaScript(md));

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -132,7 +132,7 @@ namespace Fuse.Models
 
 		void SetupModel()
 		{
-			if (_modulePath == null)
+			if (string.IsNullOrEmpty(_modulePath))
 			{
 				Code = string.Empty;
 				return;

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -20,7 +20,7 @@ namespace Fuse.Models
 			public bool HasArguments = false;
 		}
 		static PropertyHandle _modelHandle = Properties.CreateHandle();
-		
+
 		//Requires a NameTable that will be set first.
 		[UXAttachedPropertySetter("JavaScript.Model"), UXAuxNameTable("ModelNameTable")]
 		public static void SetModel(Visual v, string modulePath)
@@ -35,7 +35,7 @@ namespace Fuse.Models
 		{
 			return GetOrCreateModelData(v).ModulePath;
 		}
-		
+
 		[UXAttachedPropertySetter("ModelNameTable")]
 		public static void SetModelNameTable(Visual v, NameTable nt)
 		{
@@ -68,11 +68,11 @@ namespace Fuse.Models
 		static void OnModelDataChanged(ModelData md, Visual v)
 		{
 			v.RemoveAllChildren<ModelJavaScript>();
-			
+
 			//avoid creating without the NameTable as unfortunately UX will set the Model prior to the NameTable
 			if (md.NameTable == null || string.IsNullOrEmpty(md.ModulePath))
 				return;
-			
+
 			v.Children.Add(new ModelJavaScript(md));
 		}
 
@@ -109,7 +109,7 @@ namespace Fuse.Models
 
 				return outputArgs;
 			}
-			
+
 			return new[] { argsExpr };
 		}
 
@@ -141,7 +141,7 @@ namespace Fuse.Models
 			ZoneJS.Initialize();
 
 			var argsString = GenerateArgsStringAndPopulateDependencies();
-			var code = 
+			var code =
 					"var Model = require('FuseJS/Internal/Model');\n"+
 					"var ViewModelAdapter = require('FuseJS/Internal/ViewModelAdapter')\n"+
 					"var self = this;\n"+
@@ -156,13 +156,13 @@ namespace Fuse.Models
 					"});\n";
 			Code = code;
 		}
-		
+
 		string _previewStateModelId; //if null then not migrated
 
 		static public ModelJavaScript CreateFromPreviewState(Visual where, string modulePath)
 		{
 			string previewStateId = "ModelJavaScript-App";
-			
+
 			var previewState = PreviewState.Find(where);
 			if (previewState != null && previewState.Current != null)
 			{
@@ -175,16 +175,16 @@ namespace Fuse.Models
 						previous.Dispose();
 				}
 			}
-			
+
 			//app-level model does not have a nametable otherwise migration would not be possible
 			var md = new ModelData
 			{
 				ModulePath = modulePath
 			};
-			
+
 			return new ModelJavaScript(md, previewStateId);
 		}
-		
+
 		string _modulePath;
 		IExpression _args;
 		bool _hasArgs;
@@ -198,11 +198,11 @@ namespace Fuse.Models
 			_hasArgs = md.HasArguments;
 			FileName = "(model-script)";
 		}
-		
+
 		protected override void OnBeforeSubscribeToDependenciesAndDispatchEvaluate()
 		{
 			SetupModel();
-			
+
 			if (_previewStateModelId != null)
 			{
 				var previewState = PreviewState.Find(this);
@@ -210,13 +210,13 @@ namespace Fuse.Models
 					previewState.AddSaver(this);
 			}
 		}
-		
+
 		void IPreviewStateSaver.Save(PreviewStateData data)
 		{
 			_preserveModuleInstance = true;
 			data.Set( _previewStateModelId, this );
 		}
-		
+
 		void Dispose()
 		{
 			_preserveModuleInstance = false;

--- a/Source/Fuse.Scripting/ScriptModule.Require.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Require.uno
@@ -9,7 +9,7 @@ namespace Fuse.Scripting
 {
 	public partial class ScriptModule 
 	{
-		internal static string ModuleContainsAnErrorMessage = "require(): module contains an error: ";
+		internal const string ModuleContainsAnErrorMessage = "require(): module contains an error: ";
 
 		class RequireContext
 		{


### PR DESCRIPTION
This will avoid getting the following error when setting the Model attribute
to empty string (can't pass `null` from UX).

    Error: : Uncaught require(): module not found:
	In: Fuse.Scripting.DiagnosticSubject
	Fuse: (model-script):4

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
