### PR TITLE
Fuse.Scripting.JavaScript: skip JSC header unless needed

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/Fuse.Scripting.JavaScript.unoproj
+++ b/Source/Fuse.Scripting.JavaScript/Fuse.Scripting.JavaScript.unoproj
@@ -45,7 +45,7 @@
     "V8/lib/Windows.stuff:Stuff",
     "V8/V8.stuff:Stuff",
 
-    "JavaScriptCore/JSTypedArrayInclude.h:CHeader",
+    "JavaScriptCore/JSTypedArrayInclude.h:CHeader:USE_JAVASCRIPTCORE",
 
     "Duktape/duk_config.h:File",
     "Duktape/duktape.c:File",


### PR DESCRIPTION
This header is only needed when USE_JAVASCRIPTCORE is defined, and we don't
want it copied on all build targets.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
