### PR TITLE
Fuse.Reactive.Expressions: fix run-time warnings with LogicalNot

### DIFF
--- a/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
@@ -81,7 +81,7 @@ namespace Fuse.Reactive
 	public sealed class LogicalNot: UnaryOperator
 	{
 		[UXConstructor]
-		public LogicalNot([UXParameter("Operand")] Expression operand): base(operand) {}
+		public LogicalNot([UXParameter("Operand")] Expression operand): base(operand, Flags.None) {}
 
 		protected override bool TryCompute(object operand, out object result)
 		{


### PR DESCRIPTION
Pass Flags.None to disable the following run-time warnings:

    Warning: This constructor and use of the Is*Optional virtuals is deprecated. Pass the optionals as flags to the constructor, or specifiy Flags.None to avoid the message
    Warning: Overiding the UnaryOperator.OnNewOperand/OnLostData is deprecated. Implement `Compute` and call the other constructor, or pass Flags.None, or implement an `Expression` and `ExpressionListener` if you need the behavior (rare).

The other Negate operator found in this file already passes Flags.None,
so I believe this was just forgotten about for LogicalNot.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
