### PR TITLE
Upgrade to Uno v1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 os: osx
 osx_image: xcode9.2
-language: csharp
-mono: 5.4.1
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ In order to use Uno and Fuselibs, the following software must be installed:
 
 ### macOS
 
-* [Mono](https://www.mono-project.com/download/)
 * [Xcode](https://developer.apple.com/xcode/)
 * [CMake](https://cmake.org/)
 

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ the UI framework used to build [Fuse](https://fuseopen.com/) apps.
 npm install @fuse-open/fuselibs
 ```
 
-## Requirements
+### Requirements
 
 In order to use Uno and Fuselibs, the following software must be installed:
 
-### Windows
+#### Windows
 
 * [VCRedist 2010](https://www.microsoft.com/en-US/Download/confirmation.aspx?id=14632)
 * [VCRedist 2013](https://www.microsoft.com/en-gb/download/details.aspx?id=40784)
 
-### macOS
+#### macOS
 
 * [Xcode](https://developer.apple.com/xcode/)
 * [CMake](https://cmake.org/)
 
 To launch iOS apps from the command-line, [ios-deploy](https://www.npmjs.com/package/ios-deploy) is needed.
 
-### Android
+#### Android
 
 * Android SDK and NDK
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to use Uno and Fuselibs, the following software must be installed:
 
 ### Windows
 
-* VCRedist 2010: [x86](https://www.microsoft.com/en-us/download/details.aspx?id=5555), [x64](https://www.microsoft.com/en-US/Download/confirmation.aspx?id=14632)
+* [VCRedist 2010](https://www.microsoft.com/en-US/Download/confirmation.aspx?id=14632)
 * [VCRedist 2013](https://www.microsoft.com/en-gb/download/details.aspx?id=40784)
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ In order to use Uno and Fuselibs, the following software must be installed:
 * [Xcode](https://developer.apple.com/xcode/)
 * [CMake](https://cmake.org/)
 
+To launch iOS apps from the command-line, [ios-deploy](https://www.npmjs.com/package/ios-deploy) is needed.
+
 ### Android
 
 * Android SDK and NDK

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ To launch iOS apps from the command-line, [ios-deploy](https://www.npmjs.com/pac
 
 These dependencies can be acquired by installing [android-build-tools](https://www.npmjs.com/package/android-build-tools).
 
-## How do I build and test?
+## Building from source
+
+The following commands will install dependencies, build libraries, and
+run tests.
 
 ```
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,18 @@
   "requires": true,
   "dependencies": {
     "@fuse-open/uno": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@fuse-open/uno/-/uno-1.12.2.tgz",
-      "integrity": "sha512-N3rpyBloCqSypGsHXA/2Z+0ZJp07wg+FUui0QlLA9GAB5p6OsxOsgsgtDdw4cJXNSXjvSpQZgwgqsYnpG/IHmg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@fuse-open/uno/-/uno-1.13.0.tgz",
+      "integrity": "sha512-G/0OGn3GtRch6ZOeA7iBb29xgOQSEMw438Nr8iidohd1KzKSGxhZnUAGt9V7BBUskVo0ixw0FdVrAubxMIIbVQ==",
+      "dev": true,
+      "requires": {
+        "dotnet-run": "^1.0.0"
+      }
+    },
+    "dotnet-run": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dotnet-run/-/dotnet-run-1.0.0.tgz",
+      "integrity": "sha512-jgUouzFdtKzY+41fQPGg+F9o73DxkOpjTjWnrJKsywbTjBElWZDwluYLZrGDcmbP0kppBgaduunAXckkfWn8fA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.0",
   "description": "Fuselibs is a collection of Uno libraries that provide the UI framework used to build Fuse apps.",
   "devDependencies": {
-    "@fuse-open/uno": "^1.12.2"
+    "@fuse-open/uno": "^1.13.0"
   },
   "scripts": {
     "build": "uno doctor Source --express",


### PR DESCRIPTION
This upgrades to the newest version of Uno.

The new version of Uno installs Mono automatically, so we're dropping the Mono requirements. Also doing some light refurbishing in README.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
