### PR TITLE
iOS - Auto Resizing Mask Fix

### DIFF
--- a/Source/Fuse.iOS/AppRoot.uno
+++ b/Source/Fuse.iOS/AppRoot.uno
@@ -31,7 +31,7 @@ namespace Fuse
 			[[root layer] setAnchorPoint: { 0.0f, 0.0f }];
 			@{Fuse.Platform.SystemUI.RootView:Set(root)};
 			[root sizeToFit];
-			root.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
+			root.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin;
 			
 			return root;
 		@}


### PR DESCRIPTION
Caters for when the app is started initially in landscape, then switches to portrait, to allow the recalculation of the height and or left margin when resizing the mask. Initial behaviour was only taking into account starting from portrait and changing to landscape.