### PR TITLE
Fuse.Charting: add RadialOffset and RadialScale

### DIFF
--- a/Source/Fuse.Charting/PlotPoint.uno
+++ b/Source/Fuse.Charting/PlotPoint.uno
@@ -159,10 +159,25 @@ namespace Fuse.Charting
 	public class PlotPoint : PlotElement
 	{
 		DestinationBehavior<float2>_animator = new DestinationBehavior<float2>();
-		
+
+		/**
+			Specifies where on a circle to start drawing our points.
+
+			The range is from 0 to 1, relative to the circumference of a full circle.
+		*/
+		public float RadialOffset { get; set; }
+
+		/**
+			Specifies how much of a circle our points will consume.
+
+			The range is from 0 to 1, relative to the circumference of a full circle.
+		*/
+		public float RadialScale { get; set; }
+
 		public PlotPoint()
 		{
 			Anchor = new Size2( new Size(50, Unit.Percent), new Size(50,Unit.Percent) );
+			RadialScale = 1;
 			_calc.Init();
 		}
 		
@@ -225,6 +240,9 @@ namespace Fuse.Charting
 
 		void AnimUpdate( float2 value )
 		{
+			value.X *= RadialScale;
+			value.X += RadialOffset * Math.PIf * 2;
+
 			var p = _calc.ValueToPos(value);
 			X = new Size( p.X * 100, Unit.Percent );
 			Y = new Size( p.Y * 100, Unit.Percent );

--- a/Source/Fuse.Charting/PlotWedge.uno
+++ b/Source/Fuse.Charting/PlotWedge.uno
@@ -22,7 +22,26 @@ namespace Fuse.Charting
 	{
 		DestinationBehavior<float> _animStart = new DestinationBehavior<float>();
 		DestinationBehavior<float> _animEnd = new DestinationBehavior<float>();
-		
+
+		/**
+			Specifies where on a circle to start drawing our wedges.
+
+			The range is from 0 to 1, relative to the circumference of a full circle.
+		*/
+		public float RadialOffset { get; set; }
+
+		/**
+			Specifies how much of a circle our wedges will consume.
+
+			The range is from 0 to 1, relative to the circumference of a full circle.
+		*/
+		public float RadialScale { get; set; }
+
+		public PlotWedge()
+		{
+			RadialScale = 1;
+		}
+
 		/**
 			An @AttractorConfig used to animate a change in the shape of the wedge.
 			
@@ -65,14 +84,16 @@ namespace Fuse.Charting
 			_animEnd.SetValue( entry.CumulativeWeight.Y, AnimEnd );
 		}
 		
+		const float PI2 = Math.PIf * 2;
+
 		void AnimStart( float value )
 		{
-			StartAngle = value * Math.PIf * 2;
+			StartAngle = PI2 * RadialOffset + value * PI2 * RadialScale;
 		}
 		
 		void AnimEnd( float value )
 		{
-			EndAngle = value * Math.PIf * 2;
+			EndAngle = PI2 * RadialOffset + value * PI2 * RadialScale;
 		}
 	}
 }


### PR DESCRIPTION
New properties are needed by variations of pie chart that should not be a full circle, for example to create gauge charts and speedometers.

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
