### PR TITLE
Geo-Location - Added GetAuthorizationStatus

### DIFF
--- a/Source/Fuse.GeoLocation/Android/AndroidLocationProvider.uno
+++ b/Source/Fuse.GeoLocation/Android/AndroidLocationProvider.uno
@@ -8,7 +8,7 @@ using Fuse.GeoLocation.Android;
 
 namespace Fuse.GeoLocation
 {
-	[ForeignInclude(Language.Java, "android.support.v4.content.ContextCompat", "android.content.pm.PackageManager", "android.Manifest", "android.location.LocationManager", "android.location.Location", "android.util.Log", "java.util.List", "fuse.geolocation.UpdateListener", "android.os.Looper", "android.content.Context", "com.uno.StringArray")]
+	[ForeignInclude(Language.Java, "android.support.v4.content.ContextCompat", "android.content.pm.PackageManager", "android.Manifest", "android.location.LocationManager", "android.location.Location", "android.provider.Settings", "android.util.Log", "java.util.List", "fuse.geolocation.UpdateListener", "android.os.Looper", "android.content.Context", "com.uno.StringArray")]
 	extern(Android) class AndroidLocationProvider :  ILocationTracker
 	{
 		
@@ -105,6 +105,21 @@ namespace Fuse.GeoLocation
 				}
 			} else {
 				return false;
+			}
+		@}
+
+		[Foreign(Language.Java)]
+		public string GetAuthorizationStatus() 
+		@{
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) //API 28
+			{ 
+				android.location.LocationManager lm = (android.location.LocationManager) com.fuse.Activity.getRootActivity().getSystemService(Context.LOCATION_SERVICE);
+				return lm.isLocationEnabled() ? "on" : "off";
+			}
+			else
+			{
+				int mode = android.provider.Settings.Secure.getInt(com.fuse.Activity.getRootActivity().getContentResolver(), android.provider.Settings.Secure.LOCATION_MODE, android.provider.Settings.Secure.LOCATION_MODE_OFF);
+				return  (mode != android.provider.Settings.Secure.LOCATION_MODE_OFF) ? "on" : "off";
 			}
 		@}
 		

--- a/Source/Fuse.GeoLocation/GeoLocation.uno
+++ b/Source/Fuse.GeoLocation/GeoLocation.uno
@@ -133,6 +133,7 @@ namespace Fuse.GeoLocation
 			AddMember(onErrorEvent);
 
 			AddMember(new NativeFunction("isLocationEnabled", (NativeCallback)IsLocationEnabled));
+			AddMember(new NativeProperty<string, object>("authorizationStatus", GetAuthorizationStatus));
 			AddMember(new NativeProperty<Fuse.GeoLocation.Location, Scripting.Object>("location", GetLocation, null, Converter));
 			AddMember(new NativePromise<Fuse.GeoLocation.Location, Scripting.Object>("getLocation", GetLocationAsync, Converter));
 			AddMember(new NativeProperty<Fuse.GeoLocation.GeoLocationAuthorizationType, int>("authorizationRequest", GetAuthorizationRequest, SetAuthorizationRequest, AuthorizationRequestConverter));
@@ -150,6 +151,15 @@ namespace Fuse.GeoLocation
 		{
 			return _locationTracker.IsLocationEnabled();
 		}
+
+		/** @scriptmethod GetAuthorizationStatus() 
+		Returns the authorization status of GeoLocation
+		*/
+		string GetAuthorizationStatus() 
+		{
+			return _locationTracker.GetAuthorizationStatus();
+		}
+
 
 		/**
 			@scriptmethod startListening(minimumReportInterval, desiredAccuracy)

--- a/Source/Fuse.GeoLocation/LocationProvider.uno
+++ b/Source/Fuse.GeoLocation/LocationProvider.uno
@@ -15,6 +15,7 @@ namespace Fuse.GeoLocation
 		void StopListening();
 
 		bool IsLocationEnabled();
+		string GetAuthorizationStatus();
 
 		void RequestAuthorization(GeoLocationAuthorizationType type);
 		
@@ -88,6 +89,11 @@ namespace Fuse.GeoLocation
 		public bool IsLocationEnabled()
 		{
 			return _locationTracker.IsLocationEnabled();
+		}
+
+		public string GetAuthorizationStatus()
+		{
+			return _locationTracker.GetAuthorizationStatus();
 		}
 
 		void OnLocationChanged(Location newLocation)

--- a/Source/Fuse.GeoLocation/Spoof/SpoofLocationProvider.uno
+++ b/Source/Fuse.GeoLocation/Spoof/SpoofLocationProvider.uno
@@ -34,6 +34,11 @@ namespace Fuse.GeoLocation
 		{	
 			return false;
 		}
+		
+		public string GetAuthorizationStatus()
+		{	
+			return "never";
+		}
 
 		public void RequestAuthorization(GeoLocationAuthorizationType type)
 		{	

--- a/Source/Fuse.GeoLocation/iOS/IOSLocationProvider.uno
+++ b/Source/Fuse.GeoLocation/iOS/IOSLocationProvider.uno
@@ -130,6 +130,29 @@ namespace Fuse.GeoLocation
 		@}
 
 		[Foreign(Language.ObjC)]
+		public string GetAuthorizationStatus() 
+		@{
+			//check user authorization
+			switch ([CLLocationManager authorizationStatus]) {
+				//The user has not chosen whether the app can use location services.
+				case kCLAuthorizationStatusNotDetermined: return @"notDetermined";
+					break;
+				//The app is not authorized to use location services.
+				case kCLAuthorizationStatusRestricted: return @"restricted";
+					break;
+				//The user denied the use of location services for the app or they are disabled globally in Settings.
+				case kCLAuthorizationStatusDenied: return @"denied";
+					break;
+				//The user authorized the app to start location services at any time.
+				case kCLAuthorizationStatusAuthorizedAlways: return @"authorizedAlways";
+					break;
+				//The user authorized the app to start location services while it is in use.
+				case kCLAuthorizationStatusAuthorizedWhenInUse: return @"authorizedWhenInUse";
+					break;
+			}
+		@}
+
+		[Foreign(Language.ObjC)]
 		static void SetCLLocationManagerParams(
 			ObjC.Object handle,
 			double desiredAccuracyInMeters)


### PR DESCRIPTION
Allows us to determine the current authorization status of Geo location, so that we can cater for alternative UI regarding the UX. e.g. iOS - When the user hasn't ever set a permission, the status will be undetermined, so we can present a different UI message than that of the status being unauthorized.