### PR TITLE
iOS - InterApp - Open app fallback to open a url

### DIFF
--- a/Source/Fuse.Launcher.InterApp/InterApp/InterAppLauncher.uno
+++ b/Source/Fuse.Launcher.InterApp/InterApp/InterAppLauncher.uno
@@ -40,7 +40,7 @@ namespace Fuse.LauncherImpl
 			}
 		}
 
-		public static void LaunchApp(string uri)
+		public static void LaunchApp(string uri, string appStoreUri = null)
 		{
 			if defined(Android)
 			{
@@ -55,7 +55,7 @@ namespace Fuse.LauncherImpl
 			}
 			if defined(iOS)
 			{
-				iOSDeviceInterop.LaunchUriiOS(uri);
+				iOSDeviceInterop.LaunchApp(uri, appStoreUri);
 			}
 		}
 	}

--- a/Source/Fuse.Launcher.InterApp/InterApp/InterAppTrigger.uno
+++ b/Source/Fuse.Launcher.InterApp/InterApp/InterAppTrigger.uno
@@ -53,10 +53,11 @@ namespace Fuse.Triggers.Actions
 	public class LaunchApp : TriggerAction
 	{
 		public string Uri {get; set;}
+		public string AppStoreUri {get; set;}
 
 		protected override void Perform(Node target)
 		{
-			Fuse.LauncherImpl.InterAppLauncher.LaunchApp(this.Uri);
+			Fuse.LauncherImpl.InterAppLauncher.LaunchApp(this.Uri, this.AppStoreUri);
 		}
 	}
 }

--- a/Source/Fuse.Launcher.InterApp/InterApp/JS.uno
+++ b/Source/Fuse.Launcher.InterApp/InterApp/JS.uno
@@ -232,7 +232,14 @@ namespace Fuse.Reactive.FuseJS
 		*/
 		public static object LaunchApp(Scripting.Context context, object[] args)
 		{
-			Fuse.LauncherImpl.InterAppLauncher.LaunchApp((string)args[0]);
+			if defined(Android)
+			{
+				Fuse.LauncherImpl.InterAppLauncher.LaunchApp((string)args[0]);
+			}
+			if defined(iOS)
+			{
+				Fuse.LauncherImpl.InterAppLauncher.LaunchApp((string)args[0], (string)args[1]);
+			}
 			return null;
 		}
 	}

--- a/Source/Fuse.iOS/iOSInterop.uno
+++ b/Source/Fuse.iOS/iOSInterop.uno
@@ -56,5 +56,20 @@ namespace Fuse.iOS.Bindings
 				[[UIApplication sharedApplication] openURL:[NSURL URLWithString:uri]];
 			});
 		@}
+
+		[Foreign(Language.ObjC)]
+		public static extern(iOS) void LaunchApp(string uri, string appStoreUri)
+		@{
+			dispatch_sync(dispatch_get_main_queue(), ^{
+				if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:uri]]) 
+				{
+					[[UIApplication sharedApplication] openURL:[NSURL URLWithString:uri]];
+				} 
+				else if (appStoreUri != (id)[NSNull null] && appStoreUri.length > 0) 
+				{
+					[[UIApplication sharedApplication] openURL:[NSURL URLWithString:appStoreUri]];
+				}
+			});
+		@}
 	}
 }


### PR DESCRIPTION
Check if app is available, else can open a link (typically to App Store).

For the app that you want to open, you have to know its scheme and whitelist it:

Example:
```
whatsapp://
```
```
<Extensions Backend="CPlusPlus" Condition="iOS">
  <Require Condition="iOS" Xcode.Plist.Element>
    <![CDATA[
      <key>LSApplicationQueriesSchemes</key>
      <array>
        <string>whatsapp</string>
      </array>
    ]]>
  </Require>
</Extensions>
```