### PR TITLE
Fuse.Text: replace obsolete code

### DIFF
--- a/Source/Fuse.Text/Implementation/HarfbuzzFont.uno
+++ b/Source/Fuse.Text/Implementation/HarfbuzzFont.uno
@@ -70,22 +70,22 @@ namespace Fuse.Text.Implementation
 			{
 				var pos = i * stride;
 
-				var codepoint = Uno.Runtime.Implementation.BufferImpl.GetUInt(shapeData, pos, littleEndian);
+				var codepoint = shapeData.GetUInt(pos, littleEndian);
 				pos += sizeof(uint);
 
-				var cluster = Uno.Runtime.Implementation.BufferImpl.GetUInt(shapeData, pos, littleEndian);
+				var cluster = shapeData.GetUInt(pos, littleEndian);
 				pos += sizeof(uint);
 
-				var a1 = Uno.Runtime.Implementation.BufferImpl.GetFloat(shapeData, pos, littleEndian);
+				var a1 = shapeData.GetFloat(pos, littleEndian);
 				pos += sizeof(float);
 
-				var a2 = Uno.Runtime.Implementation.BufferImpl.GetFloat(shapeData, pos, littleEndian);
+				var a2 = shapeData.GetFloat(pos, littleEndian);
 				pos += sizeof(float);
 
-				var o1 = Uno.Runtime.Implementation.BufferImpl.GetFloat(shapeData, pos, littleEndian);
+				var o1 = shapeData.GetFloat(pos, littleEndian);
 				pos += sizeof(float);
 
-				var o2 = Uno.Runtime.Implementation.BufferImpl.GetFloat(shapeData, pos, littleEndian);
+				var o2 = shapeData.GetFloat(pos, littleEndian);
 				pos += sizeof(float);
 
 				var advance = Scale * float2(1, -1) * float2(a1, a2);

--- a/Source/Fuse.Text/Renderer.uno
+++ b/Source/Fuse.Text/Renderer.uno
@@ -344,44 +344,44 @@ namespace Fuse.Text
 
 				var littleEndian = true;
 
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectLeft, littleEndian);
+				buffer.Set(bufferPos, rectLeft, littleEndian);
 				bufferPos += sizeof(float);
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectTop, littleEndian);
-				bufferPos += sizeof(float);
-
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texLeft, littleEndian);
-				bufferPos += sizeof(ushort);
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texTop, littleEndian);
-				bufferPos += sizeof(ushort);
-
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectRight, littleEndian);
-				bufferPos += sizeof(float);
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectTop, littleEndian);
+				buffer.Set(bufferPos, rectTop, littleEndian);
 				bufferPos += sizeof(float);
 
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texRight, littleEndian);
+				buffer.Set(bufferPos, texLeft, littleEndian);
 				bufferPos += sizeof(ushort);
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texTop, littleEndian);
-				bufferPos += sizeof(ushort);
-
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectRight, littleEndian);
-				bufferPos += sizeof(float);
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectBottom, littleEndian);
-				bufferPos += sizeof(float);
-
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texRight, littleEndian);
-				bufferPos += sizeof(ushort);
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texBottom, littleEndian);
+				buffer.Set(bufferPos, texTop, littleEndian);
 				bufferPos += sizeof(ushort);
 
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectLeft, littleEndian);
+				buffer.Set(bufferPos, rectRight, littleEndian);
 				bufferPos += sizeof(float);
-				Uno.Runtime.Implementation.BufferImpl.SetFloat(buffer, bufferPos, rectBottom, littleEndian);
+				buffer.Set(bufferPos, rectTop, littleEndian);
 				bufferPos += sizeof(float);
 
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texLeft, littleEndian);
+				buffer.Set(bufferPos, texRight, littleEndian);
 				bufferPos += sizeof(ushort);
-				Uno.Runtime.Implementation.BufferImpl.SetUShort(buffer, bufferPos, texBottom, littleEndian);
+				buffer.Set(bufferPos, texTop, littleEndian);
+				bufferPos += sizeof(ushort);
+
+				buffer.Set(bufferPos, rectRight, littleEndian);
+				bufferPos += sizeof(float);
+				buffer.Set(bufferPos, rectBottom, littleEndian);
+				bufferPos += sizeof(float);
+
+				buffer.Set(bufferPos, texRight, littleEndian);
+				bufferPos += sizeof(ushort);
+				buffer.Set(bufferPos, texBottom, littleEndian);
+				bufferPos += sizeof(ushort);
+
+				buffer.Set(bufferPos, rectLeft, littleEndian);
+				bufferPos += sizeof(float);
+				buffer.Set(bufferPos, rectBottom, littleEndian);
+				bufferPos += sizeof(float);
+
+				buffer.Set(bufferPos, texLeft, littleEndian);
+				bufferPos += sizeof(ushort);
+				buffer.Set(bufferPos, texBottom, littleEndian);
 				bufferPos += sizeof(ushort);
 			}
 			return buffer;


### PR DESCRIPTION
This replaces the last remaining references to the obsolete
`Uno.Runtime.Implementation.BufferImpl` class.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
