### PR TITLE
Fuse.Controls.Native: replace foreign debug_log() calls

### DIFF
--- a/Source/Fuse.Controls.Native/ImageLoader.uno
+++ b/Source/Fuse.Controls.Native/ImageLoader.uno
@@ -277,7 +277,7 @@ namespace Fuse.Controls.Native
 			}
 			catch (Exception e)
 			{
-				debug_log("Fuse.Controls.Native.Android.ImageView: " + e.getMessage());
+				android.util.Log.e("Fuse.Controls.Native.Android.ImageView", e.getMessage());
 			}
 			return null;
 		@}
@@ -293,7 +293,7 @@ namespace Fuse.Controls.Native
 			}
 			catch (Exception e)
 			{
-				debug_log("Fuse.Controls.Native.Android.ImageView: " + e.getMessage());
+				android.util.Log.e("Fuse.Controls.Native.Android.ImageView", e.getMessage());
 			}
 			return null;
 		@}


### PR DESCRIPTION
Because this is Java code, we can use android.util.Log directly instead of
calling one of many generated and deprecated debug_log() methods.

We want to remove the generated debug_log() methods in the future.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
