### PR TITLE
build: make --express opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,22 @@ You can run the local `uno` directly using `node_modules/.bin/uno`. This
 is useful when you want to test apps using your local fuselibs build
 environment.
 
-You can run the manual testing app using one of the following commands:
+### Express building
+
+When working with the source code and building often, it can be beneficial
+to build in *express mode*.
+
+```
+npm run build -- -e
+```
+
+Express mode will only rebuild the package(s) that have actually changed,
+skipping rebuilding all dependent packages.
+
+### Manual testing
+
+You can run the manual testing app on your desired platform using one of
+the following commands:
 
 ```
 npm run android

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fuse-open/uno": "^1.13.0"
   },
   "scripts": {
-    "build": "uno doctor Source --express",
+    "build": "uno doctor Source",
     "prepack": "bash -c 'uno doctor Source --version=$npm_package_version --configuration=Release'",
     "test": "uno test Source --run-local",
     "android": "uno build android Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",


### PR DESCRIPTION
It's been observed that --express sometimes gives build-errors, but will
eventually succeed after several attempts. This seems to be caused by a bug
in Uno's caching mechanism, and the problem isn't observed when building
without --express.

Therefore, I want to revert back to building without --express by default and
instead document in README how to use --express.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
