### PR TITLE
ManualTestingApp: set iOS.BundleIdentifier

### DIFF
--- a/Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
+++ b/Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
@@ -1,4 +1,7 @@
 {
+  "iOS": {
+    "BundleIdentifier": "com.fuseopen.manualtestingapp"
+  },
   "Packages": [
     "Fuse",
     "FuseJS",


### PR DESCRIPTION
This gives ManualTestingApp a proper bundle identifier, fixing the following error when building locally using Xcode 11.

    error: No profiles for 'com.apps.manualtestingapp' were found: Xcode couldn't find any iOS App Development provisioning profiles matching 'com.apps.manualtestingapp'. Automatic signing is disabled and unable to generate a profile. To enable automatic signing, pass -allowProvisioningUpdates to xcodebuild. (in target 'ManualTestingApp' from project 'ManualTestingApp')
    ** BUILD FAILED **