### PR TITLE
iOS: fix compile-time warnings

### DIFF
--- a/Source/Fuse.ImageTools/iOS/ImagePicker.m
+++ b/Source/Fuse.ImageTools/iOS/ImagePicker.m
@@ -20,7 +20,7 @@
 		_imagePicker.sourceType = type;
 		[_imagePicker setDelegate:self];
 		[[NSOperationQueue mainQueue] addOperationWithBlock:^ {
-			[[self VC] presentViewController:_imagePicker animated:YES completion:^{ }];
+			[[self VC] presentViewController:self->_imagePicker animated:YES completion:^{ }];
 		}];
 		return YES;
 	}else{

--- a/Source/Fuse.Maps/iOS/MapViewDelegate.m
+++ b/Source/Fuse.Maps/iOS/MapViewDelegate.m
@@ -120,39 +120,39 @@
 
 		_touchRecognizer.touchesBeganCallback = ^(NSSet * touches, UIEvent * event)
 		{
-			_touchCount += [touches count];
+			self->_touchCount += [touches count];
 			if(self.touchBlock == nil) return;
 
 			UITouch* t = [touches anyObject];
-			CGPoint l = [t locationInView:_mapView];
+			CGPoint l = [t locationInView:self->_mapView];
 
-			CLLocationCoordinate2D coord = [_mapView convertPoint:l toCoordinateFromView:_mapView];
+			CLLocationCoordinate2D coord = [self->_mapView convertPoint:l toCoordinateFromView:self->_mapView];
 
-			touchBlock(0, coord.latitude, coord.longitude);
+			self->touchBlock(0, coord.latitude, coord.longitude);
 		};
 
 		_touchRecognizer.touchesEndedCallback = ^(NSSet * touches, UIEvent * event)
 		{
-			_touchCount -= [touches count];
-			if(touchBlock == nil) return;
+			self->_touchCount -= [touches count];
+			if(self->touchBlock == nil) return;
 
 			UITouch* t = [touches anyObject];
-			CGPoint l = [t locationInView:_mapView];
+			CGPoint l = [t locationInView:self->_mapView];
 
-			CLLocationCoordinate2D coord = [_mapView convertPoint:l toCoordinateFromView:_mapView];
+			CLLocationCoordinate2D coord = [self->_mapView convertPoint:l toCoordinateFromView:self->_mapView];
 
-			touchBlock(1, coord.latitude, coord.longitude);
+			self->touchBlock(1, coord.latitude, coord.longitude);
 
-			if(_touchCount==0)
-				touchBlock(4, coord.latitude, coord.longitude);
+			if(self->_touchCount==0)
+				self->touchBlock(4, coord.latitude, coord.longitude);
 		};
 
 		_touchRecognizer.touchesCancelledCallback = ^(NSSet * touches, UIEvent * event)
 		{
-			_touchCount -= [touches count];
-			if(touchBlock == nil) return;
-			if(_touchCount==0)
-				touchBlock(4, 0, 0);
+			self->_touchCount -= [touches count];
+			if(self->touchBlock == nil) return;
+			if(self->_touchCount==0)
+				self->touchBlock(4, 0, 0);
 		};
 
 		UITapGestureRecognizer* _tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onTap:)];
@@ -173,7 +173,7 @@
 		id annotation = view.annotation;
         	if (![annotation isKindOfClass:[MKUserLocation class]]) {
 			if(markerSelectBlock){
-				FusePinAnnotation* a = [view annotation];
+				FusePinAnnotation* a = (FusePinAnnotation*)[view annotation];
 				markerSelectBlock(a.markerID, a.title);
 			}
 		}
@@ -319,7 +319,7 @@
 			if (![annotation isKindOfClass:[FusePinAnnotation class]])
 				return nil;
 
-			FusePinAnnotation* a = annotation;
+			FusePinAnnotation* a = (FusePinAnnotation*)annotation;
 			if(a.icon == nil) return nil;
 			MKAnnotationView *annotationView = [[MKAnnotationView alloc] initWithAnnotation:annotation
 				reuseIdentifier:a.icon];

--- a/Source/Fuse.Platform/iOS/KeyboardContext.mm
+++ b/Source/Fuse.Platform/iOS/KeyboardContext.mm
@@ -27,7 +27,7 @@
 	else // UIKeyboardWillChangeFrameNotification
 		resizeReason = @{Fuse.Platform.SystemUIResizeReason.WillChangeFrame};	
 	
-	@{Fuse.Platform.SystemUI.uKeyboardWillChangeFrame(Uno.Platform.iOS.uCGRect, Uno.Platform.iOS.uCGRect, double, int, Fuse.Platform.SystemUIResizeReason):Call(frameBegin, frameEnd, animationDuration, animationCurve, resizeReason)};
+	@{Fuse.Platform.SystemUI.uKeyboardWillChangeFrame(Uno.Platform.iOS.uCGRect, Uno.Platform.iOS.uCGRect, double, int, Fuse.Platform.SystemUIResizeReason):Call(frameBegin, frameEnd, animationDuration, static_cast<int32_t>(animationCurve), resizeReason)};
 }
 
 @end


### PR DESCRIPTION
This fixes some compile-time warnings when building for iOS.

```
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:123:4: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:127:34: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:129:36: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:129:81: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:131:4: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:136:4: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:137:7: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:140:34: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:142:36: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:142:81: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:144:4: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:146:7: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:147:5: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:152:4: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:153:7: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:154:7: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:155:5: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:176:24: warning: initializing 'FusePinAnnotation *__strong' with an expression of incompatible type 'id<MKAnnotation> _Nullable'
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/MapViewDelegate.m:322:23: warning: initializing 'FusePinAnnotation *__strong' with an expression of incompatible type '__strong id<MKAnnotation> _Nonnull'
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/KeyboardContext.mm:30:100: warning: implicit conversion loses integer precision: 'UIViewAnimationCurve' to 'int32_t' (aka 'int') [-Wshorten-64-to-32]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/ImagePicker.m:23:37: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
```