### PR TITLE
ManualTestingApp: enable cleartext traffic on Android

### DIFF
--- a/Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
+++ b/Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
@@ -1,4 +1,7 @@
 {
+  "Android": {
+    "UsesCleartextTraffic": true
+  },
   "iOS": {
     "BundleIdentifier": "com.fuseopen.manualtestingapp"
   },


### PR DESCRIPTION
This fixes cleartext HTTP request on new Android API.

Related: https://github.com/fuse-open/uno/commit/47cf218d18ff706ccfec3fffda11260199d82339