### PR TITLE
Fuse.Vibration: fix C++ compile-error

### DIFF
--- a/Source/Fuse.Vibration/Vibration.uno
+++ b/Source/Fuse.Vibration/Vibration.uno
@@ -42,7 +42,7 @@ namespace Fuse.Vibration
 	[Require("Source.Include", "UIKit/UIKit.h")]
 	[Require("Xcode.Framework", "AudioToolbox")]
 	[ForeignInclude(Language.ObjC, "AudioToolbox/AudioToolbox.h")]
-	class IOSTapticFeedback
+	extern(iOS) class IOSTapticFeedback
 	{
 		public static extern(iOS) void Perform(VibrationType style)
 		{


### PR DESCRIPTION
Adding extern(iOS) on this class avoids receiving the following compile-time
error when building for Android, with --no-strip enabled.

    Fuse.Vibration.g.cpp:19:10: fatal error: 'UIKit/UIKit.h' file not found
    #include <UIKit/UIKit.h>
             ^~~~~~~~~~~~~~~