### PR TITLE
Fix Image bounds in NativeViewHost on iOS

### DIFF
--- a/Source/Fuse.Controls.Native/iOS/ImageView.uno
+++ b/Source/Fuse.Controls.Native/iOS/ImageView.uno
@@ -156,11 +156,8 @@ namespace Fuse.Controls.Native.iOS
 
 		public void UpdateImageTransform(float density, float2 origin, float2 scale, float2 drawSize)
 		{
-			SetTransform(_uiImageView, float4x4.Identity);
-			var imageSize = GetImageSize();
-			SetBounds(_uiImageView, 0.0f, 0.0f, imageSize.X, imageSize.Y);
-			var imageTransform = Matrix.Compose(float3(scale, 0.0f), float4.Identity, float3(origin, 0.0f));
-			SetTransform(_uiImageView, imageTransform);
+			// Set UIImageVIew size from drawSize param and avoid the use of Matrix Transformation
+			SetBounds(_uiImageView, 0.0f, 0.0f, drawSize.X, drawSize.Y);
 		}
 
 		static void SetTransform(ObjC.Object handle, float4x4 t)


### PR DESCRIPTION
This is a fix when `Image` Component placed inside a `Panel` with no size or alignment specified in `NativeViewHost` environment, 

the `Image` component size will not respect the size of its container, but instead, it will draw in accordance with the size of the image itself and the `Image` component will overlap the size of its container when the image size is larger than the container itself

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests