### PR TITLE
Add Biometric Authentication features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fuse.Auth
+- Introducing Fuse.Auth, the easiest way to perform user authentication using biometric sensor that reside on the device such as fingerprint or FaceID
+
 # 1.14
 
 ## 1.14.0

--- a/Source/Fuse.Auth/Biometric.uno
+++ b/Source/Fuse.Auth/Biometric.uno
@@ -1,0 +1,119 @@
+using Uno;
+using Uno.UX;
+using Android;
+using Uno.Threading;
+using Uno.Compiler.ExportTargetInterop;
+
+using Fuse;
+using Fuse.Platform;
+
+namespace Fuse
+{
+	[Require("Xcode.Framework","LocalAuthentication")]
+	[Require("Source.Import","LocalAuthentication/LocalAuthentication.h")]
+	extern(iOS) class IOSBiometric
+	{
+		[Foreign(Language.ObjC)]
+		public extern(iOS) static bool IsSupported()
+		@{
+			LAContext *laContext = [[LAContext alloc] init];
+			NSError *authError = nil;
+			return [laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError];
+		@}
+
+		[Foreign(Language.ObjC)]
+		public extern(iOS) static void Authenticate(string reason, Action action_success, Action<string> action_fail)
+		@{
+			LAContext *laContext = [[LAContext alloc] init];
+			NSError *authError = nil;
+			if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+			{
+				[laContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+				localizedReason:reason
+				reply:^(BOOL success, NSError *error) {
+					if (success)
+						action_success();
+					else
+						action_fail([error localizedDescription]);
+				}];
+			}
+			else
+				action_fail([authError localizedDescription]);
+		@}
+	}
+
+
+	[Require("Gradle.Dependency.Implementation", "androidx.biometric:biometric:1.0.1")]
+	[ForeignInclude(Language.Java,
+		"androidx.biometric.BiometricManager",
+		"androidx.biometric.BiometricPrompt",
+		"androidx.core.content.ContextCompat",
+		"java.util.concurrent.Executor",
+		"android.app.KeyguardManager",
+		"android.content.Context"
+	)]
+	extern(Android) class AndroidBiometric
+	{
+		[Foreign(Language.Java)]
+		public extern(Android) static bool IsSupported()
+		@{
+			BiometricManager biometricManager = BiometricManager.from(com.fuse.Activity.getRootActivity());
+			switch (biometricManager.canAuthenticate()) {
+				case BiometricManager.BIOMETRIC_SUCCESS:
+					return true;
+				case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
+					return false;
+				case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
+					return false;
+				case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
+					return false;
+			}
+			return false;
+		@}
+
+		[Foreign(Language.Java)]
+		public extern(Android) static void Authenticate(string reason, Action success, Action<string> fail)
+		@{
+			if (@{IsSupported():Call()}) {
+				Executor executor = ContextCompat.getMainExecutor(com.fuse.Activity.getRootActivity());
+				BiometricPrompt biometricPrompt = new BiometricPrompt(com.fuse.Activity.getRootActivity(),
+						executor, new BiometricPrompt.AuthenticationCallback() {
+
+					@Override
+					public void onAuthenticationError(int errorCode, CharSequence errString) {
+						super.onAuthenticationError(errorCode, errString);
+						fail.run(errString.toString());
+					}
+
+					@Override
+					public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result) {
+						super.onAuthenticationSucceeded(result);
+						success.run();
+					}
+
+					@Override
+					public void onAuthenticationFailed() {
+						super.onAuthenticationFailed();
+						fail.run("Authentication failed");
+					}
+				});
+
+				boolean isDeviceSecure = true;
+	        	BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder();
+	        	KeyguardManager kManager = (KeyguardManager) com.fuse.Activity.getRootActivity().getSystemService(Context.KEYGUARD_SERVICE);
+	        	if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+					isDeviceSecure = kManager.isDeviceSecure();
+				if (!isDeviceSecure)
+					builder = builder.setNegativeButtonText("Cancel");
+	        	builder = builder.setTitle("Biometric Authentication")
+						.setSubtitle(reason)
+						.setDeviceCredentialAllowed(isDeviceSecure)
+						.setConfirmationRequired(false);
+	        	BiometricPrompt.PromptInfo promptInfo = builder.build();
+	        	biometricPrompt.authenticate(promptInfo);
+			}else {
+				fail.run("Biometric is not supported");
+			}
+		@}
+	}
+}

--- a/Source/Fuse.Auth/Biometric.uno
+++ b/Source/Fuse.Auth/Biometric.uno
@@ -99,19 +99,19 @@ namespace Fuse
 				});
 
 				boolean isDeviceSecure = true;
-	        	BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder();
-	        	KeyguardManager kManager = (KeyguardManager) com.fuse.Activity.getRootActivity().getSystemService(Context.KEYGUARD_SERVICE);
-	        	if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+				BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder();
+				KeyguardManager kManager = (KeyguardManager) com.fuse.Activity.getRootActivity().getSystemService(Context.KEYGUARD_SERVICE);
+				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
 					isDeviceSecure = kManager.isDeviceSecure();
 				if (!isDeviceSecure)
 					builder = builder.setNegativeButtonText("Cancel");
-	        	builder = builder.setTitle("Biometric Authentication")
+				builder = builder.setTitle("Biometric Authentication")
 						.setSubtitle(reason)
 						.setDeviceCredentialAllowed(isDeviceSecure)
 						.setConfirmationRequired(false);
-	        	BiometricPrompt.PromptInfo promptInfo = builder.build();
-	        	biometricPrompt.authenticate(promptInfo);
-			}else {
+				BiometricPrompt.PromptInfo promptInfo = builder.build();
+				biometricPrompt.authenticate(promptInfo);
+			} else {
 				fail.run("Biometric is not supported");
 			}
 		@}

--- a/Source/Fuse.Auth/Fuse.Auth.unoproj
+++ b/Source/Fuse.Auth/Fuse.Auth.unoproj
@@ -1,0 +1,22 @@
+{
+  "Copyright": "Copyright (c) Fuse Open 2020",
+  "Description": "Audio playback support",
+  "Publisher": "Fuse Open",
+  "Title": "Fuse.Auth",
+  "Packages": [
+    "Uno.Threading",
+    "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse/Fuse.unoproj"
+  ],
+  "Includes": [
+    "*"
+  ],
+  "iOS": {
+    "PList": {
+      "NSFaceIDUsageDescription": "Require access to FaceID for authenticating"
+    },
+  }
+}
+

--- a/Source/Fuse.Auth/triggers/BiometricTrigger.uno
+++ b/Source/Fuse.Auth/triggers/BiometricTrigger.uno
@@ -25,11 +25,13 @@ namespace Fuse
 	{
 		protected override void OnRooted()
 		{
-			if defined(Android) {
+			if defined(Android)
+			{
 				if (AndroidBiometric.IsSupported())
 					Activate();
 			}
-			if defined(iOS) {
+			if defined(iOS)
+			{
 				if (IOSBiometric.IsSupported())
 					Activate();
 			}
@@ -38,11 +40,13 @@ namespace Fuse
 
 		protected override void OnUnrooted()
 		{
-			if defined(Android) {
+			if defined(Android)
+			{
 				if (AndroidBiometric.IsSupported())
 					Deactivate();
 			}
-			if defined(iOS) {
+			if defined(iOS)
+			{
 				if (IOSBiometric.IsSupported())
 					Deactivate();
 			}

--- a/Source/Fuse.Auth/triggers/BiometricTrigger.uno
+++ b/Source/Fuse.Auth/triggers/BiometricTrigger.uno
@@ -1,0 +1,52 @@
+using Uno;
+using Uno.UX;
+
+using Fuse.Triggers;
+using Fuse.Triggers.Actions;
+
+namespace Fuse
+{
+	/**
+		Triggers if device has biometric sensor and user has already configure it
+
+		## Example
+
+			<Panel>
+				<SupportBiometric>
+					<Button Text="Sign In With Biometric">
+						<Clicked>
+							<Authenticate />
+						</Clicked>
+					</Button>
+				</SupportBiometric>
+			</Panel>
+	*/
+	public class SupportBiometric: Trigger
+	{
+		protected override void OnRooted()
+		{
+			if defined(Android) {
+				if (AndroidBiometric.IsSupported())
+					Activate();
+			}
+			if defined(iOS) {
+				if (IOSBiometric.IsSupported())
+					Activate();
+			}
+			base.OnRooted();
+		}
+
+		protected override void OnUnrooted()
+		{
+			if defined(Android) {
+				if (AndroidBiometric.IsSupported())
+					Deactivate();
+			}
+			if defined(iOS) {
+				if (IOSBiometric.IsSupported())
+					Deactivate();
+			}
+			base.OnUnrooted();
+		}
+	}
+}

--- a/Source/Fuse.Auth/triggers/actions/BiometricAction.uno
+++ b/Source/Fuse.Auth/triggers/actions/BiometricAction.uno
@@ -64,10 +64,10 @@ namespace Fuse
 		When Using FaceID on iOS, it is mandatory to add description about why you need authentication using FaceID. You can add the description by adding this config on your `unoproj` file
 
 				"iOS": {
-    				"PList": {
-      					"NSFaceIDUsageDescription": "Require access to FaceID for authenticating"
-    				}
-  				}
+					"PList": {
+						"NSFaceIDUsageDescription": "Require access to FaceID for authenticating"
+					}
+				}
 	*/
 	public class Authenticate : TriggerAction
 	{

--- a/Source/Fuse.Auth/triggers/actions/BiometricAction.uno
+++ b/Source/Fuse.Auth/triggers/actions/BiometricAction.uno
@@ -1,0 +1,128 @@
+using Uno;
+using Uno.UX;
+
+using Fuse.Triggers;
+using Fuse.Triggers.Actions;
+using Fuse.Scripting;
+
+namespace Fuse
+{
+	public class AuthArgs : EventArgs, IScriptEvent
+	{
+		bool _status;
+		string _message;
+
+		public AuthArgs(bool result, string msg)
+		{
+			_status = result;
+			_message = msg;
+		}
+		void IScriptEvent.Serialize(IEventSerializer s)
+		{
+			Serialize(s);
+		}
+
+		virtual void Serialize(IEventSerializer s)
+		{
+			s.AddBool("status", _status);
+			s.AddString("message", _message);
+		}
+	}
+
+	public delegate void AuthEventHandler(object sender, AuthArgs args);
+
+	/**
+		This is trigger action for taking biometric authentication. Both iOS and Android is using Fingerprint/Touch ID or Face Recognition/Face ID sensor depending on what sensor are available on the device.
+		You need to add a reference to `"Fuse.Auth"` in your project file to use this feature.
+
+		## Example
+
+			The following example shows how to use it:
+
+				<JavaScript>
+					var Observable = require('FuseJS/Observable');
+					var status = Observable();
+					var statusMessage = Observable();
+
+					module.exports = {
+						status,
+						statusMessage
+						resultHandler: function(data) {
+							status.value = data.result; // bool value indicating whether true value when it succeed or false value if it failed
+							statusMessage.value = data.message;
+						}
+					};
+				</JavaScript>
+				<Panel>
+					<Button Text="Sign In" Alignment="Center">
+						<Clicked>
+							<Authenticate PromptMessage="We need your biometric data for Sign In" Handler="{resultHandler}" />
+						</Clicked>
+					</Button>
+				</Panel>
+
+		When Using FaceID on iOS, it is mandatory to add description about why you need authentication using FaceID. You can add the description by adding this config on your `unoproj` file
+
+				"iOS": {
+    				"PList": {
+      					"NSFaceIDUsageDescription": "Require access to FaceID for authenticating"
+    				}
+  				}
+	*/
+	public class Authenticate : TriggerAction
+	{
+		Node _target;
+
+		/**
+		Optionally specifies a handler that will be called when this trigger is pulsed.
+		*/
+		public event AuthEventHandler Handler;
+
+		/**
+		String message to inform user on why you need biometric data. This message only applicable for fingerprint scan
+		*/
+		public string PromptMessage
+		{
+			get; set;
+		}
+
+		public Authenticate()
+		{
+			PromptMessage = "We need your biometric information for authentication";
+		}
+
+		extern(!MOBILE)
+		protected override void Perform(Node n)
+		{
+			Fuse.Diagnostics.UserWarning("Biometric authentication is not implemented for this platform", this);
+		}
+
+		extern(MOBILE)
+		protected override void Perform(Node n)
+		{
+			_target = n;
+			if defined(iOS)
+				IOSBiometric.Authenticate(PromptMessage, AuthSuccess, AuthFailed);
+			if defined(Android)
+				AndroidBiometric.Authenticate(PromptMessage, AuthSuccess, AuthFailed);
+		}
+
+		void AuthSuccess()
+		{
+			if (Handler != null)
+			{
+				var visual = _target.FindByType<Visual>();
+				Handler(visual, new AuthArgs(true, "Authentication succeed"));
+			}
+		}
+
+		void AuthFailed(string message)
+		{
+			if (Handler != null)
+			{
+				var visual = _target.FindByType<Visual>();
+				Handler(visual, new AuthArgs(false, message));
+			}
+		}
+	}
+}


### PR DESCRIPTION
It provides the easiest way to do biometric authentication using a sensor available on the device. This feature adds a new `trigger action` called `<Authenticate/>` and `trigger class` called `<SupportBiometric/>`.

**Example**

```
<JavaScript>
    module.exports = {
        resultHandler: function(data) {
            console.dir(data.status) // boolean value true or false
        }
    }
</JavaScript>
<Panel>
    <SupportBiometric>
        <Button Text="Sign In With Biometric">
            <Clicked>
                <Authenticate PromptMessage="We need your Fingerprint" Handler="{resultHandler}" />
            </Clicked>
        </Button>
    </SupportBiometric>
</Panel>
```

**Note**
> This PR require Uno PR: https://github.com/fuse-open/uno/pull/305

This PR contains:
- [x] Changelog
- [x] Documentation
- [ ] Tests
