### PR TITLE
Add trigger action for setting device orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fuse.Auth
 - Introducing Fuse.Auth, the easiest way to perform user authentication using biometric sensor that reside on the device such as fingerprint or FaceID
 
+### Fuse.Triggers
+- Added trigger action `SetWindowOrientation` for setting device orientation
+
 # 1.14
 
 ## 1.14.0

--- a/Source/Fuse.Platform/Android/SystemUI.uno
+++ b/Source/Fuse.Platform/Android/SystemUI.uno
@@ -749,6 +749,10 @@ namespace Fuse.Platform
 					com.fuse.Activity.getRootActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT);
 					return;
 				}
+				default:
+				{
+					com.fuse.Activity.getRootActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
+				}
 			}
 		@}
 	}

--- a/Source/Fuse.Platform/Android/SystemUI.uno
+++ b/Source/Fuse.Platform/Android/SystemUI.uno
@@ -13,7 +13,8 @@ namespace Fuse.Platform
 		"android.view.View.OnLayoutChangeListener", "android.view.View",
 		"android.view.ViewTreeObserver", "android.view.Window",
 		"android.view.WindowManager", "android.widget.FrameLayout",
-		"java.lang.reflect.Method")]
+		"android.content.Context", "android.content.pm.ActivityInfo",
+		"android.view.Surface", "java.lang.reflect.Method")]
 
 	static extern(android) class SystemUI
 	{
@@ -21,7 +22,8 @@ namespace Fuse.Platform
 		static  Rect BottomFrame { get { return GetBottomBarFrame(); } }
 
 		static public event Action MarginsChanged;
-		
+		static public event Action<ScreenOrientation> DeviceOrientationChanged;
+
 		static public float4 DeviceMargins
 		{
 			get
@@ -30,7 +32,7 @@ namespace Fuse.Platform
 				return float4(0);
 			}
 		}
-		
+
 		static public float4 SafeMargins
 		{
 			get
@@ -40,18 +42,18 @@ namespace Fuse.Platform
 				return float4(0,top,0,bottom) / Density;
 			}
 		}
-		
+
 		static public float4 StaticMargins
 		{
 			get
 			{
 				var top = TopFrame.Height;
 				var bottom = _staticBottomFrameSize;
-				return float4(0,top,0,bottom) / Density; 
+				return float4(0,top,0,bottom) / Density;
 			}
 		}
-		
-		
+
+
 		static Java.Object _keyboardListener; //ViewTreeObserver.OnGlobalLayoutListener
 		static Java.Object SuperLayout; //FrameLayout
 		static Java.Object RootLayout; //FrameLayout
@@ -72,9 +74,9 @@ namespace Fuse.Platform
 		// Taken from platform2 display
 
 		static float _density = 1;
-		static public float Density 
-		{ 
-			get { return _density; } 
+		static public float Density
+		{
+			get { return _density; }
 			private set { _density = value; }
 		}
 		static private Rect _frame;
@@ -236,7 +238,7 @@ namespace Fuse.Platform
 			}
 			return (float)result;
 		@}
-		
+
 		[Foreign(Language.Java)]
 		static public void ShowStatusBar()
 		@{
@@ -339,7 +341,7 @@ namespace Fuse.Platform
 			var height = _bottomFrameSize;
 			return new Rect(float2(0, 0), float2(dispSize.X, height));
 		}
-		
+
 		static void OnWillResize()
 		{
 			if (MarginsChanged != null)
@@ -635,7 +637,7 @@ namespace Fuse.Platform
 			float h = (int)GetRealDisplayHeight();
 			return float2(w, h);
 		}
-		
+
 
 		static public int APILevel { get { return GetAPILevel(); } }
 		static public int3 OSVersion
@@ -660,18 +662,94 @@ namespace Fuse.Platform
 				return int3(major, minor, revision);
 			}
 		}
-		
+
 		[Foreign(Language.Java)]
 		static int GetAPILevel()
 		@{
 			return android.os.Build.VERSION.SDK_INT;
 		@}
-		
+
 		[Foreign(Language.Java)]
 		static string GetOSVersion()
 		@{
 			return android.os.Build.VERSION.RELEASE;
 		@}
-		
+
+		public static ScreenOrientation DeviceOrientation
+		{
+			get
+			{
+				var orientation = GetCurrentScreenOrientation();
+				switch (orientation)
+				{
+					case 0:
+						return ScreenOrientation.Portrait;
+					case 1:
+						return ScreenOrientation.LandscapeLeft;
+					case 2:
+						return ScreenOrientation.LandscapeRight;
+					case 3:
+						return ScreenOrientation.PortraitUpsideDown;
+					default:
+						return ScreenOrientation.Default;
+				}
+			}
+			set
+			{
+				if (DeviceOrientation != value)
+				{
+					SetCurrentScreenOrientation(value);
+					if (DeviceOrientationChanged != null)
+						DeviceOrientationChanged(value);
+				}
+			}
+		}
+
+		[Foreign(Language.Java)]
+		static int GetCurrentScreenOrientation()
+		@{
+			final int rotation = ((WindowManager) com.fuse.Activity.getRootActivity().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
+			switch (rotation)
+			{
+				case Surface.ROTATION_0:
+					return 0;
+				case Surface.ROTATION_270:
+					return 1;
+				case Surface.ROTATION_90:
+					return 2;
+				case Surface.ROTATION_180:
+					return 3;
+				default:
+					return 4;
+			}
+		@}
+
+		[Foreign(Language.Java)]
+		static void SetCurrentScreenOrientation(int orientation)
+		@{
+			switch (orientation)
+			{
+				case 0:
+				{
+					com.fuse.Activity.getRootActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+					return;
+				}
+				case 1:
+				{
+					com.fuse.Activity.getRootActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
+					return;
+				}
+				case 2:
+				{
+					com.fuse.Activity.getRootActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+					return;
+				}
+				case 3:
+				{
+					com.fuse.Activity.getRootActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT);
+					return;
+				}
+			}
+		@}
 	}
 }

--- a/Source/Fuse.Platform/SystemUI.uno
+++ b/Source/Fuse.Platform/SystemUI.uno
@@ -19,9 +19,18 @@ namespace Fuse.Platform
 		Fullscreen = 2,
 	}
 
+	public enum ScreenOrientation
+	{
+		Portrait,
+		LandscapeLeft,
+		LandscapeRight,
+		PortraitUpsideDown,
+		Default
+	}
+
 	/**
 		Abstract system details about the UI of the target device.
-		
+
 		This desktop version serves as the documentation for what is expected from the platform backends.
 	*/
 	static extern(!iOS && !Android) class SystemUI
@@ -30,21 +39,22 @@ namespace Fuse.Platform
 			Emitted whenever one of the `...Margins` property changes.
 		*/
 		static public event Action MarginsChanged;
-		
+		static public event Action<ScreenOrientation> DeviceOrientationChanged;
+
 		static float4 _deviceMargins = float4(0);
 		static float4 _safeMargins = float4(0);
 		static float4 _staticMargins = float4(0);
-		
+
 		/**
 			The margins the device reports as not being complete safe for drawing as something may obstruct the view, such as rounded corners or bevels.
-			
+
 			The units are the natural units of the native SDK, such that Viewport.PointsPerOSPoint would translate into Fuse points.
 		*/
 		static public float4 DeviceMargins
 		{
 			get { return _deviceMargins; }
 		}
-		
+
 		/**
 			Margins that completely exclude all system controls, device margins, or anything else which makes the area unsafe for drawing.
 		*/
@@ -60,16 +70,26 @@ namespace Fuse.Platform
 		{
 			get { return _staticMargins; }
 		}
-		
-		
+
+
 		extern(UNO_TEST) static internal void SetMargins( float4 device, float4 safe, float4 static_ )
 		{
 			_deviceMargins = device;
 			_safeMargins = safe;
 			_staticMargins = static_;
-			
+
 			if (MarginsChanged != null)
 				MarginsChanged();
+		}
+
+		public static ScreenOrientation DeviceOrientation
+		{
+			get { return ScreenOrientation.Portrait; }
+			set
+			{
+				if (DeviceOrientationChanged != null)
+					DeviceOrientationChanged(value);
+			}
 		}
 	}
 }

--- a/Source/Fuse.Platform/iOS/AppDelegateStatusBar.mm
+++ b/Source/Fuse.Platform/iOS/AppDelegateStatusBar.mm
@@ -23,6 +23,12 @@
 	@{Fuse.Platform.SystemUI._statusBarDidChangeFrame(Uno.Platform.iOS.uCGRect):Call(frame)};
 }
 
+- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window
+{
+	uAutoReleasePool pool;
+	return @{Fuse.Platform.SystemUI.supportedOrientation:Get()};
+}
+
 - (BOOL)prefersStatusBarHidden
 {
 	uAutoReleasePool pool;

--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -323,6 +323,8 @@ namespace Fuse.Platform
 			IsTopFrameVisible = false;
 		}
 
+		static public int supportedOrientation = extern<int>"UIInterfaceOrientationMaskAll";
+
 		public static ScreenOrientation DeviceOrientation
 		{
 			get
@@ -398,17 +400,35 @@ namespace Fuse.Platform
 			NSNumber * value;
 			switch (orientation)
 			{
+				case 0:
+				{
+					@{supportedOrientation:Set(UIInterfaceOrientationMaskPortrait)};
+					value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
+					break;
+				}
 				case 1:
+				{
+					@{supportedOrientation:Set(UIInterfaceOrientationMaskLandscapeLeft)};
 					value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
 					break;
+				}
 				case 2:
+				{
+					@{supportedOrientation:Set(UIInterfaceOrientationMaskLandscapeRight)};
 					value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
 					break;
+				}
 				case 3:
+				{
+					@{supportedOrientation:Set(UIInterfaceOrientationMaskPortraitUpsideDown)};
 					value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
 					break;
+				}
 				default:
+				{
+					@{supportedOrientation:Set(UIInterfaceOrientationMaskAll)};
 					value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
+				}
 			}
 			[[UIDevice currentDevice] setValue:value forKey:@"orientation"];
 		@}

--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -22,6 +22,7 @@ namespace Fuse.Platform
 	}
 
 	[Require("Source.Include", "CoreGraphics/CoreGraphics.h")]
+	[Require("Source.Include", "UIKit/UIKit.h")]
 	[Require("Source.Include", "@{Uno.Platform.iOSDisplay:Include}")]
 	[Require("Source.Include", "@{Uno.Platform.iOS.Application:Include}")]
 	[Require("Source.Include", "Uno-iOS/AppDelegate.h")]
@@ -33,15 +34,15 @@ namespace Fuse.Platform
 
 		static public Rect Frame { get; private set; }
 
-		static public float4 DeviceMargins 
-		{ 
-			get 
+		static public float4 DeviceMargins
+		{
+			get
 			{
 				return GetSafeFrame();
 			}
 		}
-		static public float4 SafeMargins 
-		{ 
+		static public float4 SafeMargins
+		{
 			get
 			{
 				float4 sf = GetSafeFrame();
@@ -50,8 +51,8 @@ namespace Fuse.Platform
 				return sf;
 			}
 		}
-		static public float4 StaticMargins 
-		{ 
+		static public float4 StaticMargins
+		{
 			get
 			{
 				float4 sm = GetSafeFrame();
@@ -59,9 +60,10 @@ namespace Fuse.Platform
 				return sm;
 			}
 		}
-		
+
 		static public event Action MarginsChanged;
-		
+		static public event Action<ScreenOrientation> DeviceOrientationChanged;
+
 		// @property (nonatomic, setter=uSetStatusBarAnimation:) UIStatusBarAnimation uStatusBarAnimation;
 		public static StatusBarAnimation uStatusBarAnimation { get; set; }
 
@@ -106,14 +108,14 @@ namespace Fuse.Platform
 			[[NSNotificationCenter defaultCenter]
 			 addObserver:ctx selector:@selector(uKeyboardWillChangeFrame:)
 			 name:UIKeyboardWillShowNotification object:nil];
-			
+
 			[[NSNotificationCenter defaultCenter]
 			 addObserver:ctx
 			 selector:@selector(uKeyboardWillChangeFrame:)
 			 name:UIKeyboardWillHideNotification object:nil];
 		@}
 
-		
+
 		[Foreign(Language.ObjC)]
 		static void DisableKeyboardResizeNotifications(ObjC.Object keyboardContext)
 		@{
@@ -122,7 +124,7 @@ namespace Fuse.Platform
 			[[NSNotificationCenter defaultCenter]
 			 removeObserver:ctx
 			 name:UIKeyboardWillShowNotification object:nil];
-			
+
 			[[NSNotificationCenter defaultCenter]
 			 removeObserver:ctx
 			 name:UIKeyboardWillHideNotification object:nil];
@@ -186,7 +188,7 @@ namespace Fuse.Platform
 				return int3(m,n,r);
 			}
 		}
-		
+
 		[Foreign(Language.ObjC)]
 		static void GetOSVersion( out int major, out int minor, out int revision )
 		@{
@@ -231,21 +233,21 @@ namespace Fuse.Platform
 					extern<Uno.Platform.iOS.uCGRect>"[UIApplication sharedApplication].statusBarFrame", null),
 				1);
 		}
-		
+
 		static float4 GetSafeFrame()
 		{
 			int major, minor, revision;
 			GetOSVersion(out major, out minor, out revision);
-			if (major >= 11) 
+			if (major >= 11)
 			{
 				float l, t, r, b;
 				GetSafeArea( out l, out t, out r, out b );
 				return float4(l,t,r,b);
 			}
-			
+
 			return float4(0);
 		}
-		
+
 		//TODO: https://github.com/fuse-open/fuselibs/issues/1015
 		//we also need to listen for safeAreInsets changes and call MarginsChanged
 		[Foreign(Language.ObjC)]
@@ -275,7 +277,7 @@ namespace Fuse.Platform
 		static void _statusBarDidChangeFrame(Uno.Platform.iOS.uCGRect _endFrame)
 		{
 		}
-		
+
 		static void uKeyboardWillChangeFrame (Uno.Platform.iOS.uCGRect frameBegin, Uno.Platform.iOS.uCGRect frameEnd, double animationDuration, int animationCurve, Fuse.Platform.SystemUIResizeReason reason)
 		{
 			_bottomFrame = Uno.Platform.iOS.Support.CGRectToUnoRect(
@@ -320,5 +322,95 @@ namespace Fuse.Platform
 		{
 			IsTopFrameVisible = false;
 		}
+
+		public static ScreenOrientation DeviceOrientation
+		{
+			get
+			{
+				var orientation = GetCurrentScreenOrientation();
+				switch (orientation)
+				{
+					case 0:
+						return ScreenOrientation.Portrait;
+					case 1:
+						return ScreenOrientation.LandscapeLeft;
+					case 2:
+						return ScreenOrientation.LandscapeRight;
+					case 3:
+						return ScreenOrientation.PortraitUpsideDown;
+					default:
+						return ScreenOrientation.Default;
+				}
+			}
+			set
+			{
+				if (DeviceOrientation != value)
+				{
+					SetCurrentScreenOrientation(value);
+					if (DeviceOrientationChanged != null)
+						DeviceOrientationChanged(value);
+				}
+			}
+		}
+
+		[Foreign(Language.ObjC)]
+		static int GetCurrentScreenOrientation()
+		@{
+			if (@available(iOS 13, *))
+			{
+				 UIInterfaceOrientation mask = [[UIApplication sharedApplication].windows firstObject].windowScene.interfaceOrientation;
+				 switch (mask)
+				 {
+				 	case UIInterfaceOrientationPortrait:
+				 		return 0;
+				 	case UIInterfaceOrientationLandscapeLeft:
+				 		return 1;
+				 	case UIInterfaceOrientationLandscapeRight:
+				 		return 2;
+				 	case UIInterfaceOrientationPortraitUpsideDown:
+				 		return 3;
+				 	case UIInterfaceOrientationUnknown:
+				 		return 4;
+				 }
+			}
+			else
+			{
+				UIInterfaceOrientationMask mask = [[UIApplication sharedApplication] statusBarOrientation];
+				switch (mask)
+				{
+					case UIInterfaceOrientationMaskPortrait:
+						return 0;
+					case UIInterfaceOrientationMaskLandscapeLeft:
+						return 1;
+					case UIInterfaceOrientationMaskLandscapeRight:
+						return 2;
+					case UIInterfaceOrientationMaskPortraitUpsideDown:
+						return 3;
+					default:
+						return 4;
+				}
+			}
+		@}
+
+		[Foreign(Language.ObjC)]
+		static void SetCurrentScreenOrientation(int orientation)
+		@{
+			NSNumber * value;
+			switch (orientation)
+			{
+				case 1:
+					value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
+					break;
+				case 2:
+					value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
+					break;
+				case 3:
+					value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
+					break;
+				default:
+					value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
+			}
+			[[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+		@}
 	}
 }

--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -358,40 +358,37 @@ namespace Fuse.Platform
 		[Foreign(Language.ObjC)]
 		static int GetCurrentScreenOrientation()
 		@{
-			if (@available(iOS 13, *))
+			#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+			 UIInterfaceOrientation mask = [[UIApplication sharedApplication].windows firstObject].windowScene.interfaceOrientation;
+			 switch (mask)
+			 {
+			 	case UIInterfaceOrientationPortrait:
+			 		return 0;
+			 	case UIInterfaceOrientationLandscapeLeft:
+			 		return 1;
+			 	case UIInterfaceOrientationLandscapeRight:
+			 		return 2;
+			 	case UIInterfaceOrientationPortraitUpsideDown:
+			 		return 3;
+			 	case UIInterfaceOrientationUnknown:
+			 		return 4;
+			 }
+			#else
+			UIInterfaceOrientationMask mask = [[UIApplication sharedApplication] statusBarOrientation];
+			switch (mask)
 			{
-				 UIInterfaceOrientation mask = [[UIApplication sharedApplication].windows firstObject].windowScene.interfaceOrientation;
-				 switch (mask)
-				 {
-				 	case UIInterfaceOrientationPortrait:
-				 		return 0;
-				 	case UIInterfaceOrientationLandscapeLeft:
-				 		return 1;
-				 	case UIInterfaceOrientationLandscapeRight:
-				 		return 2;
-				 	case UIInterfaceOrientationPortraitUpsideDown:
-				 		return 3;
-				 	case UIInterfaceOrientationUnknown:
-				 		return 4;
-				 }
+				case UIInterfaceOrientationMaskPortrait:
+					return 0;
+				case UIInterfaceOrientationMaskLandscapeLeft:
+					return 1;
+				case UIInterfaceOrientationMaskLandscapeRight:
+					return 2;
+				case UIInterfaceOrientationMaskPortraitUpsideDown:
+					return 3;
+				default:
+					return 4;
 			}
-			else
-			{
-				UIInterfaceOrientationMask mask = [[UIApplication sharedApplication] statusBarOrientation];
-				switch (mask)
-				{
-					case UIInterfaceOrientationMaskPortrait:
-						return 0;
-					case UIInterfaceOrientationMaskLandscapeLeft:
-						return 1;
-					case UIInterfaceOrientationMaskLandscapeRight:
-						return 2;
-					case UIInterfaceOrientationMaskPortraitUpsideDown:
-						return 3;
-					default:
-						return 4;
-				}
-			}
+			#endif
 		@}
 
 		[Foreign(Language.ObjC)]

--- a/Source/Fuse.Triggers/Actions/SetWindowOrientation.uno
+++ b/Source/Fuse.Triggers/Actions/SetWindowOrientation.uno
@@ -1,0 +1,30 @@
+using Uno;
+using Fuse.Platform;
+
+namespace Fuse.Triggers.Actions
+{
+	/**
+		Change Screen Orientation
+
+		## Example
+
+			<Page>
+				<Activated>
+					<SetWindowOrientation To="LandscapeLeft" />
+				</Activated>
+			</Page>
+	*/
+	public class SetWindowOrientation : TriggerAction
+	{
+		/* Target Orientation */
+		public ScreenOrientation To
+		{
+			get; set;
+		}
+
+		protected override void Perform(Node n)
+		{
+			SystemUI.DeviceOrientation = To;
+		}
+	}
+}

--- a/Source/Fuse.Triggers/Fuse.Triggers.unoproj
+++ b/Source/Fuse.Triggers/Fuse.Triggers.unoproj
@@ -42,6 +42,7 @@
     "Actions/Toggle.uno:Source",
     "Actions/TriggerAction.uno:Source",
     "Actions/Visibility.uno:Source",
+    "Actions/SetWindowOrientation.uno:Source",
     "AddingAnimation.uno:Source",
     "Busy.uno:Source",
     "Busy.ScriptClass.uno:Source",


### PR DESCRIPTION
Add `SetWindowOrientation` trigger action. With this trigger action, we can now specify different screen orientation of a `Page` in Navigation.

**Example:**

```
<Page>
     <Activated>
         <SetWindowOrientation To="LandscapeLeft" />
     </Activated>
<Page>
```

This PR contains:
- [x] Changelog
- [x] Documentation
- [ ] Tests
