### PR TITLE
Introduce DiskCachePolicy in HttpImageSource

### DIFF
--- a/Source/Experimental.Http/BinaryLoader.uno
+++ b/Source/Experimental.Http/BinaryLoader.uno
@@ -18,12 +18,12 @@ namespace Experimental.Http
 		public String Uri;
 		public String Method;
 
-		public void Initiate()
+		public void Initiate(bool cacheResponse)
 		{
-			MakeRequest();
+			MakeRequest(cacheResponse);
 		}
 
-		public void MakeRequest()
+		public void MakeRequest(bool cacheResponse)
 		{
 			if (LoaderConst.Handler == null)
 				LoaderConst.Handler = new HttpMessageHandler();
@@ -32,6 +32,7 @@ namespace Experimental.Http
 			request.Error += OnError;
 			request.Done += OnLoaded;
 			request.SetResponseType( HttpResponseType.ByteArray );
+			request.EnableCache(cacheResponse);
 			request.SendAsync();
 		}
 

--- a/Source/Experimental.Http/HttpLoader.uno
+++ b/Source/Experimental.Http/HttpLoader.uno
@@ -8,20 +8,20 @@ namespace Experimental.Http
 {
 	static public class HttpLoader
 	{
-		public static void LoadBinary(string requestUri, Action<HttpResponseHeader, byte[]> callback,
+		public static void LoadBinary(string requestUri, bool cacheResponse, Action<HttpResponseHeader, byte[]> callback,
 			Action<string> error)
 		{
 			if (callback == null)
 				throw new Exception( "LoadBinary requires callback action" );
 			if (error == null)
 				throw new Exception( "LoadBinary requires error action" );
-				
+
 			var bl = new BinaryLoader();
 			bl.Uri = requestUri;
 			bl.Method = "GET";
 			bl.Callback = callback;
 			bl.ErrorCallback = error;
-			bl.Initiate();
+			bl.Initiate(cacheResponse);
 		}
 	}
 }


### PR DESCRIPTION
`HttpImageSource` since version 1.12 has support for disk caching to store downloaded images on the local disk using `DiskCache` property, so next time when we loaded image again with the same URL it will pick up from local disk instead of making request to the network. 

But the current implementation of disk caching does not obey Http cache-control header sent by the server. So it always uses a local version even if the server mark image as stale and has to load again from the network.

We introduce `DiskCachePolicy` to give options on how DiskCache should behavior. There are two options: 
- Default: Honor cache-control header from the server
- AlwaysUseLocalCache: Always use local data if available and ignoring the cache-control header

**Note**:
This PR requires Uno PR: https://github.com/fuse-open/uno/pull/321

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
