### PR TITLE
Make static selectors internal

### DIFF
--- a/Source/Fuse.Controls.Navigation/PageControl.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.uno
@@ -314,7 +314,7 @@ namespace Fuse.Controls
 		
 		bool IsHorizontal { get { return _orient == Orientation.Horizontal; } }
 		
-		public static Selector ActiveIndexName = "ActiveIndex";
+		internal static Selector ActiveIndexName = "ActiveIndex";
 		[UXOriginSetter("SetActiveIndex")]
 		/**
 			The child index of the current active page. 

--- a/Source/Fuse.Gestures/Internal/Swiper.uno
+++ b/Source/Fuse.Gestures/Internal/Swiper.uno
@@ -55,7 +55,7 @@ namespace Fuse.Gestures.Internal
 			EndProgress = 1 << 1,
 		}
 
-		public static Selector InProgressName = "InProgress";
+		internal static Selector InProgressName = "InProgress";
 		bool _inProgress = false;
 		public bool InProgress 
 		{ 
@@ -75,7 +75,7 @@ namespace Fuse.Gestures.Internal
 			SetProgress(active ? 1 : 0, ProgressFlags.EndProgress);
 		}
 
-		public static Selector ProgressName = "Progress";
+		internal static Selector ProgressName = "Progress";
 		internal bool SetProgress(double value, ProgressFlags flags = ProgressFlags.None)
 		{
 			var interacting = flags.HasFlag(ProgressFlags.Interacting);

--- a/Source/Fuse.Navigation/VisualNavigation.uno
+++ b/Source/Fuse.Navigation/VisualNavigation.uno
@@ -226,7 +226,7 @@ namespace Fuse.Navigation
 			return pd.Index;
 		}
 
-		public static Selector ActiveIndexName = "ActiveIndex";
+		internal static Selector ActiveIndexName = "ActiveIndex";
 		[UXOriginSetter("SetActiveIndex")]
 		/**
 			The child index of the currently active page.

--- a/Source/Fuse.Nodes/Visual.Parameter.uno
+++ b/Source/Fuse.Nodes/Visual.Parameter.uno
@@ -70,7 +70,7 @@ namespace Fuse
 			}
 		}
 
-		public static Selector ParameterName = "Parameter";
+		internal static Selector ParameterName = "Parameter";
 
 		void OnParameterChanged()
 		{

--- a/Source/Fuse.Selection/Selectable.uno
+++ b/Source/Fuse.Selection/Selectable.uno
@@ -47,7 +47,7 @@ namespace Fuse.Selection
 			_selection = null;
 		}
 		
-		public static Selector ValueName = new Selector("Value");
+		internal static Selector ValueName = new Selector("Value");
 		
 		string _value;
 		/**

--- a/Source/Fuse.Selection/Selection.uno
+++ b/Source/Fuse.Selection/Selection.uno
@@ -257,7 +257,7 @@ namespace Fuse.Selection
 			get { return _values.Count; }
 		}
 		
-		public static Selector ValueName = new Selector("Value");
+		internal static Selector ValueName = new Selector("Value");
 		
 		[UXOriginSetter("SetValue")]
 		/**


### PR DESCRIPTION
These properties are used internally for caching purposes, and should not be exposed in the public API, nor show up in docs, etc.

There are instance properties available for Uno programmers. The static selector properties are unlikely to be used directly by external code, and because we are working on 2.0 it is nice to clean-up our public API a little.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
