### PR TITLE
Java packages

### DIFF
--- a/Source/Fuse.Camera/Android/AndroidCamera.uno
+++ b/Source/Fuse.Camera/Android/AndroidCamera.uno
@@ -35,7 +35,7 @@ namespace Fuse.Camera
 	[ForeignInclude(Language.Java, 
 		"android.provider.MediaStore", 
 		"com.fuse.Activity", 
-		"com.fusetools.camera.Image", 
+		"com.fuse.camera.Image", 
 		"android.os.Build",
 		"androidx.core.content.FileProvider", 
 		"java.io.File",
@@ -111,7 +111,7 @@ namespace Fuse.Camera
 		@}
 	}
 
-	[ForeignInclude(Language.Java, "com.fuse.Activity", "com.fusetools.camera.Image", "android.content.Intent", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "com.fuse.Activity", "com.fuse.camera.Image", "android.content.Intent", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) internal class TakePictureCallback
 	{
 		Promise<Image> _p;
@@ -154,7 +154,7 @@ namespace Fuse.Camera
 		}
 	}
 	
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools", "androidx.core.content.ContextCompat")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools", "androidx.core.content.ContextCompat")]
 	extern (Android) class CheckPermissionsCommand
 	{
 		public CheckPermissionsCommand(Promise<string> p)
@@ -185,7 +185,7 @@ namespace Fuse.Camera
 		@}
 	}
 	
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) class requestAndroidPermissions
 	{
 		PromiseCallback<string> _callback;

--- a/Source/Fuse.CameraRoll/Android/AndroidCameraRoll.uno
+++ b/Source/Fuse.CameraRoll/Android/AndroidCameraRoll.uno
@@ -6,7 +6,7 @@ using Fuse.ImageTools;
 using Uno.Permissions;
 namespace Fuse.CameraRoll
 {
-	[ForeignInclude(Language.Java, "com.fuse.Activity", "com.fusetools.camera.Image", "android.content.Intent", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "com.fuse.Activity", "com.fuse.camera.Image", "android.content.Intent", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) internal class SelectPictureClosure
 	{
 		Promise<Image> _p;
@@ -59,7 +59,7 @@ namespace Fuse.CameraRoll
 		}
 	}
 
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) class SelectPicturePermissionCheckCommand
 	{
 		SelectPictureClosure _closure;
@@ -103,7 +103,7 @@ namespace Fuse.CameraRoll
 		}
 	}
 
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) class AddPicturePermissionCheckCommand
 	{
 		BoolPromiseCallback _callback;
@@ -153,7 +153,7 @@ namespace Fuse.CameraRoll
 
 	}
 	
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools", "androidx.core.content.ContextCompat")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools", "androidx.core.content.ContextCompat")]
 	extern (Android) class CheckPermissionsCommand
 	{
 		public CheckPermissionsCommand(Promise<string> p)
@@ -180,7 +180,7 @@ namespace Fuse.CameraRoll
 		@}
 	}
 	
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) class requestAndroidPermissions
 	{
 		PromiseCallback<string> _callback;
@@ -213,7 +213,7 @@ namespace Fuse.CameraRoll
 
 	}
 	
-	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fusetools.camera.Image", "com.fusetools.camera.ImageStorageTools")]
+	[ForeignInclude(Language.Java, "android.provider.MediaStore", "com.fuse.Activity", "android.content.Intent", "com.fuse.camera.Image", "com.fuse.camera.ImageStorageTools")]
 	extern (Android) static internal class AndroidCameraRoll
 	{
 		internal static void SelectPicture(Promise<Image> p)

--- a/Source/Fuse.Common/Internal/AndroidSystemFont.uno
+++ b/Source/Fuse.Common/Internal/AndroidSystemFont.uno
@@ -7,7 +7,7 @@ using Uno;
 
 namespace Fuse.Internal
 {
-	[ForeignInclude(Language.Java, "fuse.android.graphics.FontListParser")]
+	[ForeignInclude(Language.Java, "com.fuse.android.graphics.FontListParser")]
 	extern(Android) static class AndroidSystemFont
 	{
 		struct Family

--- a/Source/Fuse.Common/Internal/FontListParser.java
+++ b/Source/Fuse.Common/Internal/FontListParser.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package fuse.android.graphics;
+package com.fuse.android.graphics;
 
 import android.util.Xml;
 

--- a/Source/Fuse.Controls.CameraView/Android/NativePhoto.uno
+++ b/Source/Fuse.Controls.CameraView/Android/NativePhoto.uno
@@ -12,7 +12,7 @@ using Fuse.Resources.Exif;
 namespace Fuse.Controls.Android
 {
 	[ForeignInclude(Language.Java,
-		"com.fusetools.camera.ImageStorageTools",
+		"com.fuse.camera.ImageStorageTools",
 		"java.io.File",
 		"java.io.FileOutputStream")]
 	extern(ANDROID) class NativePhoto : Photo
@@ -267,7 +267,7 @@ namespace Fuse.Controls.Android
 		}
 
 		[ForeignInclude(Language.Java,
-			"com.fusetools.camera.ImageStorageTools",
+			"com.fuse.camera.ImageStorageTools",
 			"java.lang.Thread",
 			"java.lang.Runnable",
 			"android.graphics.Bitmap",

--- a/Source/Fuse.Controls.WebView/Android/FuseWebChromeClient.java
+++ b/Source/Fuse.Controls.WebView/Android/FuseWebChromeClient.java
@@ -1,4 +1,4 @@
-package com.fusetools.webview;
+package com.fuse.webview;
 import android.webkit.WebView;
 import android.webkit.WebChromeClient;
 import android.webkit.ValueCallback;

--- a/Source/Fuse.Controls.WebView/Android/FuseWebViewClient.java
+++ b/Source/Fuse.Controls.WebView/Android/FuseWebViewClient.java
@@ -1,4 +1,4 @@
-package com.fusetools.webview;
+package com.fuse.webview;
 import android.content.Intent;
 import android.net.Uri;
 import android.webkit.WebView;

--- a/Source/Fuse.Controls.WebView/Android/JsInterface.java
+++ b/Source/Fuse.Controls.WebView/Android/JsInterface.java
@@ -1,4 +1,4 @@
-package com.fusetools.webview;
+package com.fuse.webview;
 import com.foreign.Uno.Action_String;
 import android.webkit.JavascriptInterface;
 

--- a/Source/Fuse.Controls.WebView/Android/ScrollableWebView.java
+++ b/Source/Fuse.Controls.WebView/Android/ScrollableWebView.java
@@ -1,4 +1,4 @@
-package com.fusetools.webview;
+package com.fuse.webview;
 
 import android.webkit.WebView;
 import android.content.Context;

--- a/Source/Fuse.Controls.WebView/Android/WebViewForeign.uno
+++ b/Source/Fuse.Controls.WebView/Android/WebViewForeign.uno
@@ -8,7 +8,7 @@ using Uno.Compiler.ExportTargetInterop;
 
 namespace Fuse.Android.Controls.WebViewUtils
 {
-	[ForeignInclude(Language.Java, "com.fusetools.webview.JsInterface", "com.fusetools.webview.FuseWebViewClient", "com.fusetools.webview.FuseWebChromeClient", "android.util.Log", "android.webkit.WebView", "com.fusetools.webview.ScrollableWebView")]
+	[ForeignInclude(Language.Java, "com.fuse.webview.JsInterface", "com.fuse.webview.FuseWebViewClient", "com.fuse.webview.FuseWebChromeClient", "android.util.Log", "android.webkit.WebView", "com.fuse.webview.ScrollableWebView")]
 	public static class WebViewForeign
 	{
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Drawing.Surface/Android/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/Android/GraphicsSurface.uno
@@ -28,8 +28,8 @@ namespace Fuse.Drawing
 		"android.graphics.PorterDuffXfermode",
 		"android.graphics.Matrix",
 		"android.graphics.PorterDuff.Mode",
-		"com.fusetools.drawing.surface.LinearGradientStore",
-		"com.fusetools.drawing.surface.GraphicsSurfaceContext"
+		"com.fuse.drawing.surface.LinearGradientStore",
+		"com.fuse.drawing.surface.GraphicsSurfaceContext"
 	)]
 	[ForeignInclude(Language.Java,
 		"java.nio.ByteBuffer",

--- a/Source/Fuse.Drawing.Surface/Android/GraphicsSurfaceContext.java
+++ b/Source/Fuse.Drawing.Surface/Android/GraphicsSurfaceContext.java
@@ -1,4 +1,4 @@
-package com.fusetools.drawing.surface;
+package com.fuse.drawing.surface;
 
 import android.graphics.Canvas;
 import android.graphics.Bitmap;

--- a/Source/Fuse.Drawing.Surface/Android/LinearGradientStore.java
+++ b/Source/Fuse.Drawing.Surface/Android/LinearGradientStore.java
@@ -1,4 +1,4 @@
-package com.fusetools.drawing.surface;
+package com.fuse.drawing.surface;
 
 // since we need to provide the linear gradient with
 // different stops based on the rotation of the phone

--- a/Source/Fuse.Drawing.Surface/Android/NativeSurface.uno
+++ b/Source/Fuse.Drawing.Surface/Android/NativeSurface.uno
@@ -28,8 +28,8 @@ namespace Fuse.Drawing
 		"android.graphics.PorterDuffXfermode",
 		"android.graphics.Matrix",
 		"android.graphics.PorterDuff.Mode",
-		"com.fusetools.drawing.surface.LinearGradientStore",
-		"com.fusetools.drawing.surface.GraphicsSurfaceContext",
+		"com.fuse.drawing.surface.LinearGradientStore",
+		"com.fuse.drawing.surface.GraphicsSurfaceContext",
 	)]
 	[ForeignInclude(Language.Java,
 		"java.nio.ByteBuffer",

--- a/Source/Fuse.Drawing.Surface/Android/Surface.uno
+++ b/Source/Fuse.Drawing.Surface/Android/Surface.uno
@@ -35,8 +35,8 @@ namespace Fuse.Drawing
 		"android.graphics.PorterDuffXfermode",
 		"android.graphics.Matrix",
 		"android.graphics.PorterDuff.Mode",
-		"com.fusetools.drawing.surface.LinearGradientStore",
-		"com.fusetools.drawing.surface.GraphicsSurfaceContext"
+		"com.fuse.drawing.surface.LinearGradientStore",
+		"com.fuse.drawing.surface.GraphicsSurfaceContext"
 	)]
 	[ForeignInclude(Language.Java,
 		"java.nio.ByteBuffer",

--- a/Source/Fuse.ImageTools/Android/AndroidImageUtils.uno
+++ b/Source/Fuse.ImageTools/Android/AndroidImageUtils.uno
@@ -4,7 +4,7 @@ using Uno.Compiler.ExportTargetInterop;
 using Android;
 namespace Fuse.ImageTools
 {
-	[ForeignInclude(Language.Java, "java.lang.Thread", "java.lang.Runnable", "android.util.Log", "android.provider.MediaStore", "com.fuse.Activity", "com.fusetools.camera.Image", "com.fusetools.camera.ImageUtils", "android.content.Intent")]
+	[ForeignInclude(Language.Java, "java.lang.Thread", "java.lang.Runnable", "android.util.Log", "android.provider.MediaStore", "com.fuse.Activity", "com.fuse.camera.Image", "com.fuse.camera.ImageUtils", "android.content.Intent")]
 	extern (Android) static internal class AndroidImageUtils
 	{
 

--- a/Source/Fuse.ImageTools/Android/Image.java
+++ b/Source/Fuse.ImageTools/Android/Image.java
@@ -1,4 +1,4 @@
-package com.fusetools.camera;
+package com.fuse.camera;
 
 import android.app.Activity;
 import android.content.Intent;

--- a/Source/Fuse.ImageTools/Android/ImageStorageTools.java
+++ b/Source/Fuse.ImageTools/Android/ImageStorageTools.java
@@ -1,4 +1,4 @@
-package com.fusetools.camera;
+package com.fuse.camera;
 
 import android.app.Activity;
 import android.content.ContentResolver;

--- a/Source/Fuse.ImageTools/Android/ImageUtils.java
+++ b/Source/Fuse.ImageTools/Android/ImageUtils.java
@@ -1,4 +1,4 @@
-package com.fusetools.camera;
+package com.fuse.camera;
 
 import android.app.Activity;
 import android.content.Intent;

--- a/Source/Fuse.Maps/Android/ForeignHelpers.uno
+++ b/Source/Fuse.Maps/Android/ForeignHelpers.uno
@@ -6,7 +6,7 @@ using Uno.Compiler.ExportTargetInterop;
 
 namespace Fuse.Maps.Android
 {
-	[ForeignInclude(Language.Java, "com.fusetools.maps.FuseMap", "android.util.Log", "android.graphics.Color")]
+	[ForeignInclude(Language.Java, "com.fuse.maps.FuseMap", "android.util.Log", "android.graphics.Color")]
 	extern (Android) static class ForeignHelpers
 	{
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Maps/Android/FuseMap.java
+++ b/Source/Fuse.Maps/Android/FuseMap.java
@@ -1,4 +1,4 @@
-package com.fusetools.maps;
+package com.fuse.maps;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.MotionEvent;


### PR DESCRIPTION
This renames the packages `com.fusetools` and `fuse.android.graphics` to match better with other Java-code in the repo.

The packages are internal Java packages that are unlikely to be used directly by external code, and because we are working on 2.0 it is nice to clean-up our code-base a little.

I have tested the patches locally since May on various Fuse apps I am working on without detecting any issues...

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
