### PR TITLE
iOS fix memory leak on get image orientatioon

### DIFF
--- a/Source/Fuse.Elements/Resources/Exif/Exif.uno
+++ b/Source/Fuse.Elements/Resources/Exif/Exif.uno
@@ -146,6 +146,7 @@ namespace Fuse.Resources.Exif
 				}
 				CFRelease(imageSource);
 			}
+			CFRelease(data);
 
 			int rotation = -1;
 			NSString* tagTarget = @"Orientation";


### PR DESCRIPTION
When I observe using the Instruments tool, I saw a small leak every time we process the image to get orientation information

![Untitled](https://user-images.githubusercontent.com/10460131/90421249-4cdd7000-e0e3-11ea-81df-36d990ff4bb6.jpg)

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
