### PR TITLE
Add length function

### DIFF
--- a/Source/Fuse.Reactive.Expressions/StringFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/StringFunctions.uno
@@ -46,11 +46,26 @@ namespace Fuse.Reactive
 		}
 	}
 
+	[UXFunction("length")]
+	public sealed class Length: UnaryOperator
+	{
+		[UXConstructor]
+		public Length([UXParameter("Value")] Expression value): base(value, "length") {}
+		protected override bool TryCompute(object s, out object result)
+		{
+			result = null;
+			if (s == null) return false;
+			var arr = s as IArray;
+			result = arr != null ? arr.Length : s.ToString().Length;
+			return true;
+		}
+	}
+
 	[UXFunction("indexOf")]
 	public sealed class IndexOf: BinaryOperator
 	{
 		[UXConstructor]
-		public IndexOf([UXParameter("Value")] Expression value, [UXParameter("String")] Expression str): base(value, str, "trim") {}
+		public IndexOf([UXParameter("Value")] Expression value, [UXParameter("String")] Expression str): base(value, str, "indexOf") {}
 		protected override bool TryCompute(object s, object left, out object result)
 		{
 			result = null;


### PR DESCRIPTION
Add `length` function expression for string or array 

**Example:**
```
<ClientPanel>
	<LetString ux:Name="s" Value="This is text" />
	<JavaScript>
		var arr = [1,2,3,4,5]
		module.exports = { arr }
	</JavaScript>
	<StackPanel>
		<Text Value="{s}" />
		<Text Value="{= length({s})}" />

		<Text Value="{arr}" />
		<Text Value="{= length({arr})}" />
	</StackPanel>
</ClientPanel>
```

also fix a mistake on `indexOf` function

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
