### PR TITLE
add `Style` property to DatePicker and TimePicker

### DIFF
--- a/Source/Fuse.Controls.DatePicker/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/DatePicker.uno
@@ -16,13 +16,54 @@ namespace Fuse.Controls
 		DateTime Value { set; }
 		DateTime MinValue { set; }
 		DateTime MaxValue { set; }
+		DatePickerStyle Style { set; }
 
 		void OnRooted();
 		void OnUnrooted();
 	}
 
+	/** Available DatePicker style */
+	public enum DatePickerStyle
+	{
+		Default,
+		Compact,
+		Inline,
+		/** Only available on iOS */
+		Wheels
+	}
+
 	public abstract partial class DatePickerBase : Panel
 	{
+		static Selector _styleName = "Style";
+
+		DatePickerStyle _style = DatePickerStyle.Default;
+		[UXOriginSetter("SetStyle")]
+		/** DatePicker style */
+		public DatePickerStyle Style
+		{
+			get { return _style; }
+			set { SetStyle(value, this); }
+		}
+
+		public void SetStyle(DatePickerStyle value, IPropertyListener origin)
+		{
+			if (value != _style)
+			{
+				_style = value;
+				OnStyleValueChanged(origin);
+				InvalidateLayout();
+			}
+
+			var dpv = DatePickerView;
+			if (dpv != null)
+				dpv.Style = value;
+		}
+
+		internal void OnStyleValueChanged(IPropertyListener origin)
+		{
+			OnPropertyChanged(_styleName, origin);
+		}
+
 		static Selector _valueName = "Value";
 
 		DateTime _value = DateTime.UtcNow;

--- a/Source/Fuse.Controls.TimePicker/Android/FuseTimePickerDialog.java
+++ b/Source/Fuse.Controls.TimePicker/Android/FuseTimePickerDialog.java
@@ -1,0 +1,28 @@
+package com.fuse.android.widget;
+
+import android.content.Context;
+import android.widget.TimePicker;
+import android.app.TimePickerDialog;
+import java.lang.reflect.Field;
+import android.app.TimePickerDialog.OnTimeSetListener;
+
+public class FuseTimePickerDialog extends TimePickerDialog {
+
+    TimePicker mTimePicker;
+    public FuseTimePickerDialog(Context context, OnTimeSetListener listener, int hourOfDay, int minute, boolean is24HourView) {
+
+        super(context, listener, hourOfDay, minute, is24HourView);
+        try {
+            Class<?> superClass = getClass().getSuperclass();
+            Field TimePickerField = superClass.getDeclaredField("mTimePicker");
+            TimePickerField.setAccessible(true);
+            mTimePicker = (TimePicker) TimePickerField.get(this);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public TimePicker getTimePicker() {
+        return mTimePicker;
+    }
+}

--- a/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
+++ b/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
@@ -14,6 +14,7 @@
     "../Fuse.Scripting/Fuse.Scripting.unoproj",
   ],
   "Includes": [
-    "*"
+    "*",
+    "Android/FuseTimePickerDialog.java:Java:Android"
   ]
 }

--- a/Source/Fuse.Controls.TimePicker/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/TimePicker.uno
@@ -15,13 +15,54 @@ namespace Fuse.Controls
 	{
 		DateTime Value { set; }
 		bool Is24HourView { set; }
+		TimePickerStyle Style { set; }
 
 		void OnRooted();
 		void OnUnrooted();
 	}
 
+	/** Available TimePicker style */
+	public enum TimePickerStyle
+	{
+		Default,
+		Compact,
+		Inline,
+		/** Only available on iOS */
+		Wheels
+	}
+
 	public abstract partial class TimePickerBase : Panel
 	{
+		static Selector _styleName = "Style";
+
+		TimePickerStyle _style = TimePickerStyle.Default;
+		[UXOriginSetter("SetStyle")]
+		/** TimePicker style */
+		public TimePickerStyle Style
+		{
+			get { return _style; }
+			set { SetStyle(value, this); }
+		}
+
+		public void SetStyle(TimePickerStyle value, IPropertyListener origin)
+		{
+			if (value != _style)
+			{
+				_style = value;
+				OnStyleValueChanged(origin);
+				InvalidateLayout();
+			}
+
+			var dpv = TimePickerView;
+			if (dpv != null)
+				dpv.Style = value;
+		}
+
+		internal void OnStyleValueChanged(IPropertyListener origin)
+		{
+			OnPropertyChanged(_styleName, origin);
+		}
+
 		static Selector _valueName = "Value";
 
 		DateTime _value = DateTime.UtcNow;


### PR DESCRIPTION
There are 4 styles available:
- Default
- Compact
- Inline
- Wheels (Only available on iOS)

This also fixes the rendering error on iOS 14 as reported in [forum](https://forums.fusetools.com/t/datepicker-not-showing-correctly-on-ios-14-2/8092/3)

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
