### PR TITLE
MaxLines property on Text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fuse.Controls.Primitives
 - `TextControl` accessibility feature. Introduce `MinFontScale` and `MaxFontScale` Property to control the minimum or maximum text scaling behavior when the text/font size configuration setting on the phone has changed. Now default Fuse will honor the phone's text/font size configuration setting and will change all of the texts or labels in the Fuse App to match the setting. If you don't want the behavior you can pass a compiler flag:`IGNORE_FONT_SCALING` when building the app i.e: `uno build ios -DIGNORE_FONT_SCALING`
+- Added `MaxLines` property to the `Text` component to limit the number of lines when `TextWrapping` property is set to `Wrap`
 - Added support for `Shadow` Behavior in `NativeViewHost`
 - Added support for rendering backdrop filter of glass effect using the new `Glass` behavior
 

--- a/Source/Fuse.Android.TextRenderer/Internal/StaticLayout.uno
+++ b/Source/Fuse.Android.TextRenderer/Internal/StaticLayout.uno
@@ -37,9 +37,10 @@ namespace Fuse.Android
 			Alignment align,
 			float spacingMult,
 			float spacingAdd,
-			bool includePad)
-			
-			: this( Create(text, paint.Handle, width, (int)align, spacingMult, spacingAdd, includePad) ) { }
+			bool includePad,
+			int maxLines)
+
+			: this( Create(text, paint.Handle, width, (int)align, spacingMult, spacingAdd, includePad, maxLines) ) { }
 
 		public StaticLayout(
 			string text,
@@ -175,7 +176,8 @@ namespace Fuse.Android
 			int align,
 			float spacingMult,
 			float spacingAdd,
-			bool includePad)
+			bool includePad,
+			int maxLines)
 		@{
 			// Be careful, doing stupid enum conversion
 			android.text.Layout.Alignment alignment = android.text.Layout.Alignment.ALIGN_CENTER;
@@ -184,7 +186,13 @@ namespace Fuse.Android
 
 			android.text.TextPaint paint = (android.text.TextPaint)paintHandle;
 
-			return new android.text.StaticLayout(text, paint, width, alignment, spacingMult, spacingAdd, includePad);
+			android.text.StaticLayout.Builder builder = android.text.StaticLayout.Builder.obtain(text, 0, text.length(), paint, width);
+			return builder.setMaxLines(maxLines == 0 ? Integer.MAX_VALUE : maxLines)
+				.setAlignment(alignment)
+				.setIncludePad(includePad)
+				.setLineSpacing(spacingAdd, spacingMult)
+				.setEllipsize(android.text.TextUtils.TruncateAt.END)
+				.build();
 		@}
 
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Android.TextRenderer/TextRenderer.uno
+++ b/Source/Fuse.Android.TextRenderer/TextRenderer.uno
@@ -60,11 +60,11 @@ namespace Fuse.Android
 				var layoutWidth = (int)Math.Ceil(Math.Max(wrapWidthPixels, desiredWidth));
 				Layout = (Control.TextTruncation == Fuse.Controls.TextTruncation.Standard)
 					? new StaticLayout(text, 0, text.Length, Paint, layoutWidth, align, 1.0f, lineSpacing, false, TextUtils.TruncateAt.End, width)
-					: new StaticLayout(text, Paint, layoutWidth, align, 1.0f, lineSpacing, false);
+					: new StaticLayout(text, Paint, layoutWidth, align, 1.0f, lineSpacing, false, Control.MaxLines);
 			}
 			else
 			{
-				Layout = new StaticLayout(text, Paint, width, align, 1.0f, lineSpacing, false);
+				Layout = new StaticLayout(text, Paint, width, align, 1.0f, lineSpacing, false, Control.MaxLines);
 			}
 
 			var bounds = new Uno.Rect(0, 0, 0, 0);

--- a/Source/Fuse.Controls.Native/Android/TextView.uno
+++ b/Source/Fuse.Controls.Native/Android/TextView.uno
@@ -25,6 +25,14 @@ namespace Fuse.Controls.Native.Android
 			}
 		}
 
+		int ITextView.MaxLines
+		{
+			set
+			{
+				if (value > 0) SetMaxLines(Handle, value);
+			}
+		}
+
 		public TextWrapping TextWrapping
 		{
 			set { SetTextWrapping(Handle, value == Fuse.Controls.TextWrapping.Wrap); }
@@ -114,6 +122,15 @@ namespace Fuse.Controls.Native.Android
 		static void SetLineSpacing(Java.Object handle, float spacing)
 		@{
 			((android.widget.TextView)handle).setLineSpacing(spacing, 1.0f);
+		@}
+
+		[Foreign(Language.Java)]
+		static void SetMaxLines(Java.Object handle, int line)
+		@{
+			android.widget.TextView tv = (android.widget.TextView)handle;
+			tv.setEllipsize(android.text.TextUtils.TruncateAt.END);
+			tv.setHorizontallyScrolling(false);
+			tv.setMaxLines(line);
 		@}
 
 		[Foreign(Language.Java)]

--- a/Source/Fuse.Controls.Native/Interfaces.uno
+++ b/Source/Fuse.Controls.Native/Interfaces.uno
@@ -25,6 +25,7 @@ namespace Fuse.Controls.Native
 	{
 		string Value { set; }
 		int MaxLength { set; }
+		int MaxLines { set; }
 		TextWrapping TextWrapping { set; }
 		float LineSpacing { set; }
 		float FontSize { set;}

--- a/Source/Fuse.Controls.Native/iOS/TextEdit.uno
+++ b/Source/Fuse.Controls.Native/iOS/TextEdit.uno
@@ -88,6 +88,11 @@ namespace Fuse.Controls.Native.iOS
 			set { SetMaxLength(_delegate, (value == 0) ? int.MaxValue : value); }
 		}
 
+		int ITextView.MaxLines
+		{
+			set { /* TODO */ }
+		}
+
 		[Foreign(Language.ObjC)]
 		static void SetMaxLength(ObjC.Object delegateHandle, int maxLength)
 		@{
@@ -544,6 +549,11 @@ namespace Fuse.Controls.Native.iOS
 		{
 			// TODO: fix the value == 0 crap
 			set { SetMaxLength(_delegate, (value == 0) ? int.MaxValue : value); }
+		}
+
+		int ITextView.MaxLines
+		{
+			set { /* TODO */ }
 		}
 
 		[Foreign(Language.ObjC)]

--- a/Source/Fuse.Controls.Native/iOS/TextView.uno
+++ b/Source/Fuse.Controls.Native/iOS/TextView.uno
@@ -37,6 +37,14 @@ namespace Fuse.Controls.Native.iOS
 			set { }
 		}
 
+		int ITextView.MaxLines
+		{
+			set
+			{
+				if (value > 0) SetTextLines(Handle, value);
+			}
+		}
+
 		TextWrapping ITextView.TextWrapping
 		{
 			set

--- a/Source/Fuse.Controls.Primitives/TextControls/FallbackTextRenderer/TextRenderer.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/FallbackTextRenderer/TextRenderer.uno
@@ -111,32 +111,37 @@ namespace Fuse.Controls.FallbackTextRenderer
 			float minX = 0.0f;
 			float height = 0.0f;
 			int maxTextLength = 0;
+			int currLine = 0;
 
 			foreach (var wrappedLine in _wrappedLines)
 			{
-				var extent = float2(0, wrappedLine.LineWidth);
-
-				if (!useMin)
+				if (Control.MaxLines > 0 && currLine < Control.MaxLines)
 				{
-					switch (Control.TextAlignment)
-					{
-						case TextAlignment.Left:
-							extent = float2(0,wrappedLine.LineWidth);
-							break;
-						case TextAlignment.Right:
-							extent = float2(wrapWidth - wrappedLine.LineWidth, wrapWidth);
-							break;
-						case TextAlignment.Center:
-							extent = float2(wrapWidth/2 - wrappedLine.LineWidth/2,
-								wrapWidth/2 + wrappedLine.LineWidth/2);
-							break;
-					}
-				}
+					var extent = float2(0, wrappedLine.LineWidth);
 
-				minX = Math.Min(minX,extent[0]);
-				maxX = Math.Max(maxX,extent[1]);
-				maxTextLength += wrappedLine.Text.Length;
-				height += _wrapInfo.LineHeight;
+					if (!useMin)
+					{
+						switch (Control.TextAlignment)
+						{
+							case TextAlignment.Left:
+								extent = float2(0,wrappedLine.LineWidth);
+								break;
+							case TextAlignment.Right:
+								extent = float2(wrapWidth - wrappedLine.LineWidth, wrapWidth);
+								break;
+							case TextAlignment.Center:
+								extent = float2(wrapWidth/2 - wrappedLine.LineWidth/2,
+									wrapWidth/2 + wrappedLine.LineWidth/2);
+								break;
+						}
+					}
+
+					minX = Math.Min(minX,extent[0]);
+					maxX = Math.Max(maxX,extent[1]);
+					maxTextLength += wrappedLine.Text.Length;
+					height += _wrapInfo.LineHeight;
+				}
+				currLine++;
 			}
 
 			//TODO: https://github.com/fusetools/fuselibs-private/issues/1386

--- a/Source/Fuse.Controls.Primitives/TextControls/FuseTextRenderer/CacheState.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/FuseTextRenderer/CacheState.uno
@@ -14,6 +14,7 @@ namespace Fuse.Controls.FuseTextRenderer
 		public readonly TextAlignment TextAlignment;
 		public readonly float LineSpacing;
 		public readonly float PixelWidth;
+		public readonly int MaxLines;
 
 		public TextControlData(Fuse.Text.Font font, Fuse.Controls.TextControl control, float pixelWidth)
 		{
@@ -24,6 +25,7 @@ namespace Fuse.Controls.FuseTextRenderer
 			TextAlignment = control.TextAlignment;
 			LineSpacing = control.LineSpacing * control.Viewport.PixelsPerPoint;
 			PixelWidth = pixelWidth;
+			MaxLines = control.MaxLines;
 		}
 
 		public bool Subsumes(TextControlData other, Tolerances tolerances, bool measureOnly)
@@ -44,6 +46,7 @@ namespace Fuse.Controls.FuseTextRenderer
 				&& TextWrapping == other.TextWrapping
 				&& TextTruncation == other.TextTruncation
 				&& TextAlignment == other.TextAlignment
+				&& MaxLines == other.MaxLines
 				&& Math.Abs(LineSpacing - other.LineSpacing) <= Tolerances.Epsilon
 				&& withinWrapTolerance
 				&& tolerances.MinTruncation - Tolerances.Epsilon <= PixelWidth
@@ -80,6 +83,7 @@ namespace Fuse.Controls.FuseTextRenderer
 					data.Font,
 					shapedRuns,
 					data.PixelWidth + Tolerances.Epsilon,
+					data.MaxLines,
 					out tolerances.MinWrap,
 					out tolerances.MaxWrap)
 				: shapedRuns;

--- a/Source/Fuse.Controls.Primitives/TextControls/TextControl.Forwarding.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/TextControl.Forwarding.uno
@@ -10,6 +10,7 @@ namespace Fuse.Controls
 		public static readonly Selector MaxLengthPropertyName = "MaxLength";
 		public static readonly Selector TextWrappingPropertyName = "TextWrapping";
 		public static readonly Selector LineSpacingPropertyName = "LineSpacing";
+		public static readonly Selector MaxLinesPropertyName = "MaxLines";
 		public static readonly Selector FontSizePropertyName = "FontSize";
 		public static readonly Selector FontPropertyName = "Font";
 		public static readonly Selector TextAlignmentPropertyName = "TextAlignment";
@@ -36,6 +37,7 @@ namespace Fuse.Controls
 			tv.Font = Font;
 			tv.TextAlignment = TextAlignment;
 			tv.TextColor = Color;
+			tv.MaxLines = MaxLines;
 		}
 
 		protected virtual void OnValueChanged(IPropertyListener origin)
@@ -77,6 +79,16 @@ namespace Fuse.Controls
 			OnPropertyChanged(LineSpacingPropertyName);
 			var edit = GetITextView();
 			if (edit != null) edit.LineSpacing = LineSpacing;
+			InvalidateLayout();
+			InvalidateVisual();
+			InvalidateRenderer();
+		}
+
+		protected virtual void OnMaxLinesChanged()
+		{
+			OnPropertyChanged(MaxLinesPropertyName);
+			var edit = GetITextView();
+			if (edit != null) edit.MaxLines = MaxLines;
 			InvalidateLayout();
 			InvalidateVisual();
 			InvalidateRenderer();

--- a/Source/Fuse.Controls.Primitives/TextControls/TextControl.Properties.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/TextControl.Properties.uno
@@ -120,6 +120,21 @@ namespace Fuse.Controls
 			}
 		}
 
+		/** Specifies the maximum number line of text if TextWrapping set to Wrap
+		*/
+		public int MaxLines
+		{
+			get { return Get(FastProperty2.MaxLines, 0); }
+			set
+			{
+				if (MaxLines != value)
+				{
+					Set(FastProperty2.MaxLines, value, 0);
+					OnMaxLinesChanged();
+				}
+			}
+		}
+
 		float _fontSize = Font.PlatformDefaultSize;
 		public float FontSize
 		{

--- a/Source/Fuse.Nodes/Visual.FastProperties2.uno
+++ b/Source/Fuse.Nodes/Visual.FastProperties2.uno
@@ -20,7 +20,8 @@ namespace Fuse
 		IsPassword = 1<<12,
 		IsReadOnly = 1<<13,
 		AutoCorrectHint = 1<<14,
-		AutoCapitalizationHint = 1<<15
+		AutoCapitalizationHint = 1<<15,
+		MaxLines = 1<<16,
 	}
 
 	class FastProperty2Link
@@ -37,7 +38,7 @@ namespace Fuse
 	class FastProperty2Link<T>: FastProperty2Link
 	{
 		public T Value;
-		public FastProperty2Link(FastProperty2 p, T value) : base(p) 
+		public FastProperty2Link(FastProperty2 p, T value) : base(p)
 		{
 			Value = value;
 		}
@@ -62,7 +63,7 @@ namespace Fuse
 				if (object.Equals(value, defaultValue)) Clear(p);
 				else Find<T>(p).Value = value;
 			}
-			else 
+			else
 			{
 				if (!object.Equals(value, defaultValue)) Insert<T>(p, value);
 			}
@@ -142,7 +143,7 @@ namespace Fuse
 			return null;
 		}
 
-		
+
 	}
 
 }

--- a/Source/Fuse.Text/Wrap.uno
+++ b/Source/Fuse.Text/Wrap.uno
@@ -33,6 +33,7 @@ namespace Fuse.Text
 			Font font,
 			List<List<ShapedRun>> logicalLineRuns,
 			float maxPixelWidth,
+			int maxLines,
 			out float minTolerance, out float maxTolerance)
 		{
 			minTolerance = 0;
@@ -42,7 +43,22 @@ namespace Fuse.Text
 			{
 				WrapLine(font, maxPixelWidth, ref minTolerance, ref maxTolerance, line, result);
 			}
+			if (maxLines > 0 && result.Count > maxLines)
+			{
+				result = result.Take(maxLines).ToList();
+				// adding `...`
+				InsertTruncationSringSymbol(font, result);
+				return result;
+			}
 			return result;
+		}
+
+		static void InsertTruncationSringSymbol(Font font, List<List<ShapedRun>> lines)
+		{
+			var truncationSrun = new ShapedRun(
+					new Run(new Substring(Font.Truncation), 0),
+					font.ShapedTruncation);
+			lines[lines.Count - 1].Add(truncationSrun);
 		}
 
 		static void WrapLine(

--- a/Source/Fuse.Text/Wrap.uno
+++ b/Source/Fuse.Text/Wrap.uno
@@ -47,13 +47,13 @@ namespace Fuse.Text
 			{
 				result = result.Take(maxLines).ToList();
 				// adding `...`
-				InsertTruncationSringSymbol(font, result);
+				InsertTruncationStringSymbol(font, result);
 				return result;
 			}
 			return result;
 		}
 
-		static void InsertTruncationSringSymbol(Font font, List<List<ShapedRun>> lines)
+		static void InsertTruncationStringSymbol(Font font, List<List<ShapedRun>> lines)
 		{
 			var truncationSrun = new ShapedRun(
 					new Run(new Substring(Font.Truncation), 0),

--- a/Source/Fuse.iOS.TextRenderer/TextRenderer.uno
+++ b/Source/Fuse.iOS.TextRenderer/TextRenderer.uno
@@ -58,7 +58,7 @@ namespace Fuse.iOS.Bindings
 			if (control.TextTruncation == Fuse.Controls.TextTruncation.None &&
 				control.TextWrapping == TextWrapping.NoWrap)
 				width = 0;
-			TextContainer = CreateNSTextContainer(width, size.Y);
+			TextContainer = CreateNSTextContainer(width, size.Y, control.MaxLines);
 			AddNSTextContainer(LayoutManager, TextContainer);
 
 			SetNSParagraphStyleProperties(
@@ -102,10 +102,15 @@ namespace Fuse.iOS.Bindings
 		@}
 
 		[Foreign(Language.ObjC)]
-		public static ObjC.Object CreateNSTextContainer(float width, float height)
+		public static ObjC.Object CreateNSTextContainer(float width, float height, int maxLines)
 		@{
 			NSTextContainer* result = [[NSTextContainer alloc] initWithSize:CGSizeMake(width, height)];
 			result.lineFragmentPadding = 0;
+			if (maxLines > 0)
+			{
+				result.maximumNumberOfLines =  maxLines;
+				result.lineBreakMode = NSLineBreakByTruncatingTail;
+			}
 			return result;
 		@}
 


### PR DESCRIPTION
Added `MaxLines` property to the `Text` component to limit the number of lines to display when `TextWrapping` property is set to `Wrap`

**Examples**:
```
<ClientPanel>
	StackPanel ItemSpacing="10">
		<Text Value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
		<Text Value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." TextWrapping="Wrap" />
		<Text Value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." MaxLines="3" TextWrapping="Wrap" Color="Red" />
	</StackPanel>
</CllientPanel>
```

This PR contains:
- [x] Changelog
- [x] Documentation
- [ ] Tests
