### PR TITLE
Fuse.Charting: fix old deprecation warnings in test

### DIFF
--- a/Source/Fuse.Charting/Tests/FilterObservable.Test.uno
+++ b/Source/Fuse.Charting/Tests/FilterObservable.Test.uno
@@ -68,9 +68,9 @@ namespace Fuse.Test
 				source.Add( "X" );
 				for (int i=0; i < 100; ++i)
 				{
-					source.Insert( r.NextInt(source.Count), "" + i );
+					source.Insert( r.Next(source.Count), "" + i );
 					if (i % 3 == 0)
-						source.RemoveAt( r.NextInt(source.Count) );
+						source.RemoveAt( r.Next(source.Count) );
 						
 					var q = "";
 					for (int j=2; j < sa.Length - 2; ++j)


### PR DESCRIPTION
NextInt() has been deprecated since at least v1.9, I believe.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
