### PR TITLE
appveyor: drop legacy mesa-download

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,6 @@ environment:
 install:
   - npm install
   - npm install android-build-tools -g
-  - ps: Invoke-WebRequest https://www.nuget.org/api/v2/package/mesa3d-x64/18.3.4 -OutFile mesa.zip
-  - ps: Expand-Archive mesa.zip mesa
 
 build_script:
   - npm pack --silent
@@ -23,14 +21,6 @@ build_script:
 
 artifacts:
   - path: '*.tgz'
-
-before_test:
-  - ps: |
-      Get-ChildItem -Path Source -Recurse -Include *Test.unoproj | Select-Object -ExpandProperty DirectoryName | Foreach-Object {
-        $buildDir = Join-Path $_ build\Test\DotNet
-        New-Item -Force -ItemType directory -Path $buildDir | Out-Null
-        Copy-Item -Path mesa\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
-      }
 
 test_script:
   - npm run test


### PR DESCRIPTION
The Mesa 3D library (used here as a software OpenGL renderer) has been
redundant since at least v1.9 because we've since been using ANGLE for
OpenGL support in .NET builds on Windows (translating to Direct3D 9).

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
