### PR TITLE
doc-export: add Fuse.Auth reference

### DIFF
--- a/tools/doc-export/doc-export.unoproj
+++ b/tools/doc-export/doc-export.unoproj
@@ -19,7 +19,8 @@
         "Fuse.Controls.CameraView",
         "Fuse.UXKits.Alive",
         "Fuse.Models",
-        "Fuse.Sensor"
+        "Fuse.Sensor",
+        "Fuse.Auth"
     ],
     "Includes": [
         "*"


### PR DESCRIPTION
Documentation for Fuse.Auth should be included in our API docs, and
therefore also included in the doc-export project.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
