### PR TITLE
Fuse.Controls.CameraView: fix type-name typo in doc-comment

### DIFF
--- a/Source/Fuse.Controls.CameraView/VideoTools.uno
+++ b/Source/Fuse.Controls.CameraView/VideoTools.uno
@@ -12,7 +12,7 @@ namespace Fuse.VideoTools
 
 		Utility methods for video files manipulation. Currently only supports moving a video file to the camera roll.
 
-		> To use this module, add `Fuse.CameraView` to your package references in your `.unoproj`.
+		> To use this module, add `Fuse.Controls.CameraView` to your package references in your `.unoproj`.
 
 
 		## Example


### PR DESCRIPTION
Related to https://github.com/fuse-open/docs/pull/41

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
