### PR TITLE
WhileScrolling Trigger

### DIFF
--- a/Source/Fuse.Controls.ScrollView/Triggers/WhileScrolling.uno
+++ b/Source/Fuse.Controls.ScrollView/Triggers/WhileScrolling.uno
@@ -1,0 +1,60 @@
+using Uno;
+using Fuse;
+using Fuse.Triggers;
+using Fuse.Controls;
+
+/**
+	Trigger that will active while the @ScrollView is in motion
+**/
+public class WhileScrolling : WhileTrigger
+{
+
+	ScrollViewBase _scrollable;
+
+	protected override void OnRooted()
+	{
+		base.OnRooted();
+		_scrollable = Parent.FindByType<ScrollViewBase>();
+		if (_scrollable == null)
+		{
+			Fuse.Diagnostics.UserError( "WhileScrolling could not find a Scrollable control.", this );
+			return;
+		}
+		_scrollable.ScrollPositionChanged += OnScrollPositionChanged;
+	}
+
+	protected override void OnUnrooted()
+	{
+		if (_scrollable != null)
+		{
+			_scrollable.ScrollPositionChanged -= OnScrollPositionChanged;
+			_scrollable = null;
+		}
+		base.OnUnrooted();
+	}
+
+	bool _isActive = false;
+	int _prevFrameIndex = 0;
+
+	void OnScrollPositionChanged(object sender, EventArgs args)
+	{
+		if (!_isActive)
+		{
+			_isActive = true;
+			SetActive(true);
+			UpdateManager.AddAction(OnUpdate);
+		}
+		_prevFrameIndex = UpdateManager.FrameIndex;
+	}
+
+	void OnUpdate()
+	{
+		if (_prevFrameIndex < UpdateManager.FrameIndex)
+		{
+			SetActive(false);
+			_isActive = false;
+			UpdateManager.RemoveAction(OnUpdate);
+		}
+	}
+
+}

--- a/Source/Fuse.Controls.ScrollView/Triggers/WhileScrolling.uno
+++ b/Source/Fuse.Controls.ScrollView/Triggers/WhileScrolling.uno
@@ -4,7 +4,7 @@ using Fuse.Triggers;
 using Fuse.Controls;
 
 /**
-	Trigger that will active while the @ScrollView is in motion
+	Trigger that will become active while the @ScrollView is in motion
 **/
 public class WhileScrolling : WhileTrigger
 {


### PR DESCRIPTION
Trigger that will active while the ScrollView is in motion

**Example**:

```
<App>
	<ClientPanel>
		<Panel>
			<Rectangle ux:Name="indicator" Color="#838383" CornerRadius="5" Width="8" Height="80" Alignment="TopRight"
				Opacity="0" />
			<ScrollView ux:Name="scrollview">
				<ScrollingAnimation>
					<Move Y="0.95" Target="indicator" RelativeNode="scrollview" RelativeTo="Size" />
				</ScrollingAnimation>
				<WhileScrolling>
					<Change indicator.Opacity="1" Duration="0.1" DelayBack="1" />
				</WhileScrolling>
				<StackPanel ItemSpacing="10">
					<Each Count="100">
						<Panel Height="40" Color="#CDCDCD">
							<Text Value="Item #{index()}" Alignment="VerticalCenter" Margin="10" />
						</Panel>
					</Each>
				</StackPanel>
			</ScrollView>
		</Panel>
	</ClientPanel>
</App>
```

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
