### PR TITLE
Update ModuleInstance.uno

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
@@ -14,7 +14,7 @@ namespace Fuse.Scripting.JavaScript
 		public ModuleInstance(IThreadWorker worker, Reactive.JavaScript js)
 		{
 			for (var i = 0; i < js.Dependencies.Count; i++)
-				_deps.Add(js.Dependencies[i].Name, js.Dependencies[i].Value);
+				_deps[js.Dependencies[i].Name] = js.Dependencies[i].Value;
 
 			_js = js;
 			_worker = worker;


### PR DESCRIPTION
Fixes an edge use case where navigation possibly reloads a page which tries to re-add a module again with the same key in the dictionary, thereby throwing a dictionary error which crashes the app: https://github.com/fuse-open/uno/blob/b9bd80402a775f3572e1bf84e32b28b2706de971/lib/UnoCore/Source/Uno/Collections/Dictionary.uno#L358
