### PR TITLE
Fix text rendering on Android

### DIFF
--- a/Source/Fuse.Android.TextRenderer/Fuse.Android.TextRenderer.unoproj
+++ b/Source/Fuse.Android.TextRenderer/Fuse.Android.TextRenderer.unoproj
@@ -17,6 +17,7 @@
   ],
   "Includes": [
     "*",
-    "Internal/*"
+    "Internal/*",
+    "StaticLayoutBuilder.java:Java:Android"
   ]
 }

--- a/Source/Fuse.Android.TextRenderer/Internal/StaticLayout.uno
+++ b/Source/Fuse.Android.TextRenderer/Internal/StaticLayout.uno
@@ -186,6 +186,9 @@ namespace Fuse.Android
 
 			android.text.TextPaint paint = (android.text.TextPaint)paintHandle;
 
+			if (android.os.Build.VERSION.SDK_INT < 23)
+				return com.fuse.android.text.StaticLayoutBuilder.create(text, 0, text.length(), paint, width, alignment, spacingMult, spacingAdd, includePad, android.text.TextUtils.TruncateAt.END, width, maxLines == 0 ? Integer.MAX_VALUE : maxLines);
+
 			android.text.StaticLayout.Builder builder = android.text.StaticLayout.Builder.obtain(text, 0, text.length(), paint, width);
 			return builder.setMaxLines(maxLines == 0 ? Integer.MAX_VALUE : maxLines)
 				.setAlignment(alignment)

--- a/Source/Fuse.Android.TextRenderer/StaticLayoutBuilder.java
+++ b/Source/Fuse.Android.TextRenderer/StaticLayoutBuilder.java
@@ -1,0 +1,114 @@
+package com.fuse.android.text;
+
+import android.os.Build;
+import android.text.Layout.Alignment;
+import android.text.StaticLayout;
+import android.text.TextDirectionHeuristic;
+import android.text.TextDirectionHeuristics;
+import android.text.TextPaint;
+import android.text.TextUtils.TruncateAt;
+import android.util.Log;
+
+import java.lang.reflect.Constructor;
+
+public class StaticLayoutBuilder {
+	private static final String LOGTAG = "StaticLayoutBuilder";
+
+	private static final String TEXT_DIR_CLASS = "android.text.TextDirectionHeuristic";
+	private static final String TEXT_DIRS_CLASS = "android.text.TextDirectionHeuristics";
+	private static final String TEXT_DIR_FIRSTSTRONG_LTR = "FIRSTSTRONG_LTR";
+
+	private static boolean sInitialized;
+
+	private static Constructor<StaticLayout> sConstructor;
+	private static Object[] sConstructorArgs;
+	private static Object sTextDirection;
+
+	public static synchronized void ensureInitialized() {
+		if (sInitialized) {
+			return;
+		}
+
+		try {
+			final Class<?> textDirClass;
+			if (Build.VERSION.SDK_INT >= 18) {
+				textDirClass = TextDirectionHeuristic.class;
+				sTextDirection = TextDirectionHeuristics.FIRSTSTRONG_LTR;
+			} else {
+				final ClassLoader loader = StaticLayoutBuilder.class.getClassLoader();
+				textDirClass = loader.loadClass(TEXT_DIR_CLASS);
+
+				final Class<?> textDirsClass = loader.loadClass(TEXT_DIRS_CLASS);
+				sTextDirection = textDirsClass.getField(TEXT_DIR_FIRSTSTRONG_LTR).get(textDirsClass);
+			}
+
+			final Class<?>[] signature = new Class[] {
+					CharSequence.class,
+					int.class,
+					int.class,
+					TextPaint.class,
+					int.class,
+					Alignment.class,
+					textDirClass,
+					float.class,
+					float.class,
+					boolean.class,
+					TruncateAt.class,
+					int.class,
+					int.class
+			};
+
+			// Make the StaticLayout constructor with max lines public
+			sConstructor = StaticLayout.class.getDeclaredConstructor(signature);
+			sConstructor.setAccessible(true);
+			sConstructorArgs = new Object[signature.length];
+		} catch (NoSuchMethodException e) {
+			Log.e(LOGTAG, "StaticLayout constructor with max lines not found.", e);
+		} catch (ClassNotFoundException e) {
+			Log.e(LOGTAG, "TextDirectionHeuristic class not found.", e);
+		} catch (NoSuchFieldException e) {
+			Log.e(LOGTAG, "TextDirectionHeuristics.FIRSTSTRONG_LTR not found.", e);
+		} catch (IllegalAccessException e) {
+			Log.e(LOGTAG, "TextDirectionHeuristics.FIRSTSTRONG_LTR not accessible.", e);
+		} finally {
+			sInitialized = true;
+		}
+	}
+
+	public static boolean isSupported() {
+		if (Build.VERSION.SDK_INT < 14) {
+			return false;
+		}
+
+		ensureInitialized();
+		return (sConstructor != null);
+	}
+
+	public static synchronized StaticLayout create(CharSequence source, int bufstart, int bufend,
+												   TextPaint paint, int outerWidth, Alignment align,
+												   float spacingMult, float spacingAdd,
+												   boolean includePad, TruncateAt ellipsize,
+												   int ellipsisWidth, int maxLines) {
+		ensureInitialized();
+
+		try {
+			sConstructorArgs[0] = source;
+			sConstructorArgs[1] = bufstart;
+			sConstructorArgs[2] = bufend;
+			sConstructorArgs[3] = paint;
+			sConstructorArgs[4] = outerWidth;
+			sConstructorArgs[5] = align;
+			sConstructorArgs[6] = sTextDirection;
+			sConstructorArgs[7] = spacingMult;
+			sConstructorArgs[8] = spacingAdd;
+			sConstructorArgs[9] = includePad;
+			sConstructorArgs[10] = ellipsize;
+			sConstructorArgs[11] = ellipsisWidth;
+			sConstructorArgs[12] = maxLines;
+
+			return sConstructor.newInstance(sConstructorArgs);
+		} catch (Exception e) {
+			throw new IllegalStateException("Error creating StaticLayout with max lines: " + e);
+		}
+	}
+}

--- a/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
@@ -342,25 +342,28 @@ namespace Fuse.Controls
 
 			target.setHorizontallyScrolling(!isMultiline);
 
-			if (updateTextAlignment)
+			if (android.os.Build.VERSION.SDK_INT < 17)
 			{
-				// This piece of code fixes the textalignment issues we have
-				// been having for a long time. What happens is that TextView/EditText
-				// has some internal state for text alignment that is not updated when
-				// setting properties like textAlignment/gravity/scroll etc.
-				// Reading the TextView code, I found that the following method
-				// calls will hit the codepaths that update the text alignment state
-				target.setSelection(source.getSelectionStart(), source.getSelectionEnd());
-				target.layout(0, 0, width, height);
-				target.onPreDraw();
-			}
-			else
-			{
-				// One cause of the issue above is that the source TextEdit's scrollposition
-				// does not have a valid value. One frame after changing textalignment this state
-				// will be valid
-				target.setScrollX(source.getScrollX());
-				target.setScrollY(source.getScrollY());
+				if (updateTextAlignment)
+				{
+					// This piece of code fixes the textalignment issues we have
+					// been having for a long time. What happens is that TextView/EditText
+					// has some internal state for text alignment that is not updated when
+					// setting properties like textAlignment/gravity/scroll etc.
+					// Reading the TextView code, I found that the following method
+					// calls will hit the codepaths that update the text alignment state
+					target.setSelection(source.getSelectionStart(), source.getSelectionEnd());
+					target.layout(0, 0, width, height);
+					target.onPreDraw();
+				}
+				else
+				{
+					// One cause of the issue above is that the source TextEdit's scrollposition
+					// does not have a valid value. One frame after changing textalignment this state
+					// will be valid
+					target.setScrollX(source.getScrollX());
+					target.setScrollY(source.getScrollY());
+				}
 			}
 		@}
 


### PR DESCRIPTION
This PR contains 2 fixes:
- TextView bugs when we set alignment to the center, on lost focus the text become disappear. the issues reported on #1399
- Fix regression introduced by this PR #1385. the app will crash on Android pre-Marshmallow when we set `TextWrapping` to `Wrap`

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
