### PR TITLE
Android: don't add BACKGROUND_LOCATION to manifest

### DIFF
--- a/Source/Fuse.Android.Permissions/AndroidPermissionsInternal.uxl
+++ b/Source/Fuse.Android.Permissions/AndroidPermissionsInternal.uxl
@@ -8,7 +8,8 @@
         </Method>
 
         <Method Signature="_access_background_location():Fuse.Android.Permissions.PlatformPermission">
-            <Require AndroidManifest.Permission="android.permission.ACCESS_BACKGROUND_LOCATION" />
+            <!-- Disabled due to errors when publishing on Google Play. Please add this permission manually if really needed. -->
+            <!-- <Require AndroidManifest.Permission="android.permission.ACCESS_BACKGROUND_LOCATION" /> -->
         </Method>
 
         <Method Signature="_access_coarse_location():Fuse.Android.Permissions.PlatformPermission">

--- a/Source/Fuse.Android.Permissions/Permissions.uxl
+++ b/Source/Fuse.Android.Permissions/Permissions.uxl
@@ -8,7 +8,8 @@
         </Method>
 
         <Method Signature="_access_background_location():Fuse.Android.Permissions.PlatformPermission">
-            <Require AndroidManifest.Permission="android.permission.ACCESS_BACKGROUND_LOCATION" />
+            <!-- Disabled due to errors when publishing on Google Play. Please add this permission manually if really needed. -->
+            <!-- <Require AndroidManifest.Permission="android.permission.ACCESS_BACKGROUND_LOCATION" /> -->
         </Method>
 
         <Method Signature="_access_coarse_location():Fuse.Android.Permissions.PlatformPermission">


### PR DESCRIPTION
Apps with this permission declared in their manifest are rejected when
submitting to Google Play, unless providing a video demonstrating how
this functionality is used in the app.

The problem with some apps is that they aren't really using this feature
so there's nothing to demonstrate, and the only way to publish currently
is to manually edit AndroidManifest.xml, remove the permission, re-run
build.sh, and finally submit the modified AAB/APK.

This patch addresses the problem by not adding this permission
automatically. Apps that really need it will be required to add it
manually. Please report issues if this becomes a problem for anyone.

Closes #1402

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
