### PR TITLE
InAppBrowser Launcher

### DIFF
--- a/Source/Fuse.Launcher.InAppBrowser/Fuse.Launcher.InAppBrowser.unoproj
+++ b/Source/Fuse.Launcher.InAppBrowser/Fuse.Launcher.InAppBrowser.unoproj
@@ -1,0 +1,17 @@
+{
+  "Copyright": "Copyright (c) Fuse Open 2021",
+  "Description": "Native Launcher",
+  "Publisher": "Fuse Open",
+  "Projects": [
+    "../Fuse.Triggers/Fuse.Triggers.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Android/Fuse.Android.unoproj",
+    "../Fuse.iOS/Fuse.iOS.unoproj"
+  ],
+  "Includes": [
+    "InAppBrowserLauncher.uno",
+    "JS.uno",
+    "Trigger.uno",
+  ]
+}

--- a/Source/Fuse.Launcher.InAppBrowser/InAppBrowserLauncher.uno
+++ b/Source/Fuse.Launcher.InAppBrowser/InAppBrowserLauncher.uno
@@ -1,0 +1,71 @@
+using Uno;
+using Uno.UX;
+using Uno.Threading;
+using Uno.Compiler.ExportTargetInterop;
+
+namespace Fuse.LauncherImpl
+{
+	public static class InAppBrowserLauncher
+	{
+		public static void LaunchInAppBrowser(string url)
+		{
+			if defined(iOS)
+				InAppBrowseriOSImpl.OpenUrl(url);
+			if defined(Android)
+				InAppBrowserAndroidImpl.OpenUrl(url);
+		}
+
+	}
+
+	extern(iOS) class InAppBrowseriOSImpl
+	{
+
+		public static void OpenUrl(string url)
+		{
+			Safari.PresentSafari(url);
+		}
+
+	}
+
+	extern(Android) class InAppBrowserAndroidImpl
+	{
+
+		public static void OpenUrl(string url)
+		{
+			Chrome.PresentChrome(url);
+		}
+
+	}
+
+	[Require("Xcode.Framework", "SafariServices")]
+	[ForeignInclude(Language.ObjC, "AVFoundation/AVFoundation.h")]
+	[Require("Source.Include", "UIKit/UIKit.h")]
+	[Require("Source.Include", "SafariServices/SafariServices.h")]
+	public extern(iOS) class Safari
+	{
+		[Foreign(Language.ObjC)]
+		public static void PresentSafari(string url)
+		@{
+			NSURL* u = [[NSURL alloc] initWithString: url];
+			SFSafariViewController* vc = [[SFSafariViewController alloc] initWithURL: u entersReaderIfAvailable:NO];
+			dispatch_async(dispatch_get_main_queue(), ^{
+				[[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:vc animated:YES completion:nil];
+			});
+		@}
+
+	}
+
+	[Require("Gradle.Dependency.Implementation", "androidx.browser:browser:1.3.0")]
+	[ForeignInclude(Language.Java, "androidx.browser.customtabs.CustomTabsIntent", "android.net.Uri")]
+	public extern(Android) class Chrome
+	{
+
+		[Foreign(Language.Java)]
+		public static void PresentChrome(string url)
+		@{
+			CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+			CustomTabsIntent customTabsIntent = builder.build();
+			customTabsIntent.launchUrl(com.fuse.Activity.getRootActivity(), Uri.parse(url));
+		@}
+	}
+}

--- a/Source/Fuse.Launcher.InAppBrowser/InAppBrowserLauncher.uno
+++ b/Source/Fuse.Launcher.InAppBrowser/InAppBrowserLauncher.uno
@@ -55,7 +55,7 @@ namespace Fuse.LauncherImpl
 
 	}
 
-	[Require("Gradle.Dependency.Implementation", "androidx.browser:browser:1.3.0")]
+	[Require("Gradle.Dependency.Implementation", "androidx.browser:browser:1.0.0")]
 	[ForeignInclude(Language.Java, "androidx.browser.customtabs.CustomTabsIntent", "android.net.Uri")]
 	public extern(Android) class Chrome
 	{

--- a/Source/Fuse.Launcher.InAppBrowser/JS.uno
+++ b/Source/Fuse.Launcher.InAppBrowser/JS.uno
@@ -1,0 +1,47 @@
+using Uno;
+using Uno.UX;
+using Uno.Collections;
+using Fuse.Scripting;
+
+namespace Fuse.Reactive.FuseJS
+{
+	[UXGlobalModule]
+	/**
+		@scriptmodule FuseJS/InAppBrowser
+
+		The InAppBrowser API allows you to launch In App Browser
+
+		You need to add a reference to `"Fuse.Launcher"` in your project file to use this feature.
+
+		## Example
+
+			var inAppBrowser = require("FuseJS/InAppBrowser");
+			inAppBrowser.openUrl("https://fuseopen.com");
+	*/
+	public class InAppBrowserModule : NativeModule
+	{
+		static InAppBrowserModule _instance;
+
+		public InAppBrowserModule()
+		{
+			if (_instance != null)
+				return;
+
+			_instance = this;
+			Resource.SetGlobalKey(_instance, "FuseJS/InAppBrowser");
+
+			AddMember(new NativeFunction("openUrl", (NativeCallback)OpenUrl));
+		}
+
+		object[] OpenUrl(Context c, object[] args)
+		{
+			var url = args.ValueOrDefault<string>(0,"");
+			if (url == "")
+				throw new Exception("You need to supply a valid url");
+
+			Fuse.LauncherImpl.InAppBrowserLauncher.LaunchInAppBrowser(url);
+			return null;
+		}
+	}
+
+}

--- a/Source/Fuse.Launcher.InAppBrowser/JS.uno
+++ b/Source/Fuse.Launcher.InAppBrowser/JS.uno
@@ -15,8 +15,10 @@ namespace Fuse.Reactive.FuseJS
 
 		## Example
 
+		```javascript
 			var inAppBrowser = require("FuseJS/InAppBrowser");
 			inAppBrowser.openUrl("https://fuseopen.com");
+		```
 	*/
 	public class InAppBrowserModule : NativeModule
 	{

--- a/Source/Fuse.Launcher.InAppBrowser/Trigger.uno
+++ b/Source/Fuse.Launcher.InAppBrowser/Trigger.uno
@@ -1,0 +1,38 @@
+using Uno;
+
+namespace Fuse.Triggers.Actions
+{
+
+	/** Launch the default map app
+
+		You'll find this trigger action in the Fuse.Launcher package, which have to be referenced from your uno project.
+		For example:
+
+			{
+				"Packages": [
+					"Fuse",
+					"FuseJS",
+					"Fuse.Launcher"
+				]
+			}
+
+		## Example
+
+			<StackPanel Margin="20">
+				<Button Margin="10" Text="Launch InApp Browser">
+					<Clicked>
+						<LaunchInAppBrowser Url="https://fuseopen.com" />
+					</Clicked>
+				</Button>
+			</StackPanel>
+	*/
+	public class LaunchInAppBrowser : TriggerAction
+	{
+		public string Url {get; set;}
+
+		protected override void Perform(Node target)
+		{
+			Fuse.LauncherImpl.InAppBrowserLauncher.LaunchInAppBrowser(Url);
+		}
+	}
+}

--- a/Source/Fuse.Launcher.InAppBrowser/Trigger.uno
+++ b/Source/Fuse.Launcher.InAppBrowser/Trigger.uno
@@ -8,6 +8,7 @@ namespace Fuse.Triggers.Actions
 		You'll find this trigger action in the Fuse.Launcher package, which have to be referenced from your uno project.
 		For example:
 
+		```json
 			{
 				"Packages": [
 					"Fuse",
@@ -15,9 +16,11 @@ namespace Fuse.Triggers.Actions
 					"Fuse.Launcher"
 				]
 			}
+		```
 
 		## Example
 
+		```xml
 			<StackPanel Margin="20">
 				<Button Margin="10" Text="Launch InApp Browser">
 					<Clicked>
@@ -25,6 +28,7 @@ namespace Fuse.Triggers.Actions
 					</Clicked>
 				</Button>
 			</StackPanel>
+		```
 	*/
 	public class LaunchInAppBrowser : TriggerAction
 	{

--- a/Source/Fuse.Launcher/Fuse.Launcher.unoproj
+++ b/Source/Fuse.Launcher/Fuse.Launcher.unoproj
@@ -11,7 +11,8 @@
     "../Fuse.Launcher.Email/Fuse.Launcher.Email.unoproj",
     "../Fuse.Launcher.InterApp/Fuse.Launcher.InterApp.unoproj",
     "../Fuse.Launcher.Maps/Fuse.Launcher.Maps.unoproj",
-    "../Fuse.Launcher.Phone/Fuse.Launcher.Phone.unoproj"
+    "../Fuse.Launcher.Phone/Fuse.Launcher.Phone.unoproj",
+    "../Fuse.Launcher.InAppBrowser/Fuse.Launcher.InAppBrowser.unoproj",
   ],
   "Includes": [
     "Launcher.uno:Source",

--- a/Source/Fuse.Launcher/Launcher.uno
+++ b/Source/Fuse.Launcher/Launcher.uno
@@ -40,5 +40,10 @@ namespace Fuse
 		{
 			EmailLauncher.LaunchEmail(to, carbonCopy, blindCarbonCopy, subject, message);
 		}
+
+		public static void LaunchInAppBrowser(string url)
+		{
+			InAppBrowserLauncher.LaunchInAppBrowser(url);
+		}
 	}
 }


### PR DESCRIPTION
launch `InAppBrowser` using `SFSafariViewController` on iOS and Chrome `CustomTabs` on Android

# Example:
```
App Background="#000">
	<JavaScript>
		module.exports.launch = function(args) {
		    var inAppBrowser = require("FuseJS/InAppBrowser");
		    inAppBrowser.openUrl("https://fuseopen.com");
		}
	</JavaScript>
	<StackPanel Margin="20">
		<Button Margin="10" Text="Launch InApp Browser">
			<Clicked>
				<LaunchInAppBrowser Url="https://fuseopen.com" />
			</Clicked>
		</Button>
		<Button Margin="10" Text="Launch InApp Browser Via JS">
			<Clicked Handler="{launch}" />
		</Button>
	</StackPanel>
</App>
```
This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
