### PR TITLE
TextEditRenderer: enable horizontal scrolling only on lower version of android

### DIFF
--- a/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
@@ -335,15 +335,16 @@ namespace Fuse.Controls
 
 			target.setLayoutParams(new android.widget.FrameLayout.LayoutParams(width, height));
 
-			if (android.os.Build.VERSION.SDK_INT >= 17)
-				target.setTextAlignment(android.view.View.TEXT_ALIGNMENT_GRAVITY);
-
 			target.setGravity(source.getGravity());
 
-			target.setHorizontallyScrolling(!isMultiline);
-
-			if (android.os.Build.VERSION.SDK_INT < 17)
+			if (android.os.Build.VERSION.SDK_INT >= 17)
 			{
+				target.setTextAlignment(android.view.View.TEXT_ALIGNMENT_GRAVITY);
+				target.setHorizontallyScrolling(false);
+			}
+			else
+			{
+				target.setHorizontallyScrolling(!isMultiline);
 				if (updateTextAlignment)
 				{
 					// This piece of code fixes the textalignment issues we have


### PR DESCRIPTION
This is a workaround fix for the issue: https://github.com/fuse-open/fuselibs/issues/1407. When we set alignment to the center or right on the recent version of Android, on lost focus the text won't visible.
related issue: 

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
