### PR TITLE
Silent obsolete warning message

### DIFF
--- a/Source/Fuse.Common/Diagnostics.uno
+++ b/Source/Fuse.Common/Diagnostics.uno
@@ -45,24 +45,24 @@ namespace Fuse
 
 		internal bool IsTemporalWarning;
 
-		internal Uno.Diagnostics.DebugMessageType UnoType
+		internal Uno.Diagnostics.LogLevel UnoType
 		{
 			get
 			{
 				switch (Type)
 				{
 					case DiagnosticType.UserSuccess:
-						return Uno.Diagnostics.DebugMessageType.Information;
+						return Uno.Diagnostics.LogLevel.Information;
 
 					case DiagnosticType.UserWarning:
 					case DiagnosticType.Deprecated:
 					case DiagnosticType.Unsupported:
 					case DiagnosticType.PerformanceWarning:
-						return Uno.Diagnostics.DebugMessageType.Warning;
+						return Uno.Diagnostics.LogLevel.Warning;
 
 					case DiagnosticType.UserError:
 					case DiagnosticType.InternalError:
-						return Uno.Diagnostics.DebugMessageType.Error;
+						return Uno.Diagnostics.LogLevel.Error;
 
 					default:
 						throw new Exception("invalid Type: " + Type);
@@ -179,7 +179,7 @@ namespace Fuse
 			if (DiagnosticReported != null)
 				DiagnosticReported(d);
 			else
-				Uno.Diagnostics.Debug.Log(d.Format(false), d.UnoType);
+				Uno.Diagnostics.Log.WriteLine(d.UnoType, d.Format(false));
 		}
 
 		class Temporal: IDisposable
@@ -207,7 +207,7 @@ namespace Fuse
 			if (DiagnosticReported != null)
 				DiagnosticReported(d);
 
-			Uno.Diagnostics.Debug.Log(d.ToString(), d.UnoType);
+			Uno.Diagnostics.Log.WriteLine(d.UnoType, d.ToString());
 			return new Temporal(d);
 		}
 

--- a/Source/Fuse.Nodes/AppBase.uno
+++ b/Source/Fuse.Nodes/AppBase.uno
@@ -158,7 +158,7 @@ namespace Fuse
 		{
 			//don't use Fuse.Diagnostics.UnknownException, that assumes a sane error path, but
 			//at this point we don't have one anymore and thus Diagnostics may not be able to report correctly
-			Uno.Diagnostics.Debug.Log(e.ToString(), Uno.Diagnostics.DebugMessageType.Error);
+			Uno.Diagnostics.Log.WriteLine(Uno.Diagnostics.LogLevel.Error, e.ToString());
 			if (UnhandledException != null)
 			{
 				var args = new UnhandledExceptionArgs(e);

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/DebugLog.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/DebugLog.uno
@@ -35,31 +35,31 @@ namespace Fuse.Reactive
 			c.GlobalObject["console"] = console;
 		}
 
-		static object LogInternal(Context context, object[] args, Uno.Diagnostics.DebugMessageType debugMessageType)
+		static object LogInternal(Context context, object[] args, Uno.Diagnostics.LogLevel logLevel)
 		{
 			var formatted = Format(context, args);
-			Uno.Diagnostics.Debug.Log(formatted, debugMessageType);
+			Uno.Diagnostics.Log.WriteLine(logLevel, formatted);
 			return null;
 		}
 
 		static object Log(Context context, object[] args)
 		{
-			return LogInternal(context, args, Uno.Diagnostics.DebugMessageType.Debug);
+			return LogInternal(context, args, Uno.Diagnostics.LogLevel.Debug);
 		}
 
 		static object Warn(Context context, object[] args)
 		{
-			return LogInternal(context, args, Uno.Diagnostics.DebugMessageType.Warning);
+			return LogInternal(context, args, Uno.Diagnostics.LogLevel.Warning);
 		}
 
 		static object Info(Context context, object[] args)
 		{
-			return LogInternal(context, args, Uno.Diagnostics.DebugMessageType.Information);
+			return LogInternal(context, args, Uno.Diagnostics.LogLevel.Information);
 		}
 
 		static object Error(Context context, object[] args)
 		{
-			return LogInternal(context, args, Uno.Diagnostics.DebugMessageType.Error);
+			return LogInternal(context, args, Uno.Diagnostics.LogLevel.Error);
 		}
 
 		static string Format(Context context, object[] args)

--- a/Source/Fuse.Testing/TestRootPanel.uno
+++ b/Source/Fuse.Testing/TestRootPanel.uno
@@ -132,7 +132,7 @@ namespace Fuse.Testing
 
 		void OnDiagnostic(Diagnostic d)
 		{
-			if (d.UnoType == Uno.Diagnostics.DebugMessageType.Error)
+			if (d.UnoType == Uno.Diagnostics.LogLevel.Error)
 			{
 				_errors.Add(d);
 			}

--- a/Source/Fuse.Triggers/Actions/DebugAction.uno
+++ b/Source/Fuse.Triggers/Actions/DebugAction.uno
@@ -38,13 +38,13 @@ namespace Fuse.Triggers.Actions
 			if defined(DEBUG)
 			{
 				if (Message != null)
-					Uno.Diagnostics.Debug.Log(Message);
+					Uno.Diagnostics.Log.Debug(Message);
 
 				if (_props != null)
 				{
 					foreach (ITaggedDebugProperty prop in _props)
 					{
-						Uno.Diagnostics.Debug.Log(prop.GetTag() + " = " + prop.GetStringValue());
+						Uno.Diagnostics.Log.Debug(prop.GetTag() + " = " + prop.GetStringValue());
 					}
 				}
 			}


### PR DESCRIPTION
Change `Uno.Diagnostics.Debug` to `Uno.Diagnostics.Log` to silent warning when doing `uno doctor`

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
