### PR TITLE
Tweak swipe edge navigation

### DIFF
--- a/Source/Fuse.Controls.Navigation/NavigatorSwipe.uno
+++ b/Source/Fuse.Controls.Navigation/NavigatorSwipe.uno
@@ -113,15 +113,19 @@ namespace Fuse.Controls
 					break;
 				case NavigatorSwipeDirection.LeftEdge:
 					_swipeGesture.Edge = Fuse.Gestures.Edge.Left;
+					_swipeGesture.HitSize = 10;
 					break;
 				case NavigatorSwipeDirection.RightEdge:
 					_swipeGesture.Edge = Fuse.Gestures.Edge.Right;
+					_swipeGesture.HitSize = 10;
 					break;
 				case NavigatorSwipeDirection.Top:
 					_swipeGesture.Edge = Fuse.Gestures.Edge.Top;
+					_swipeGesture.HitSize = 10;
 					break;
 				case NavigatorSwipeDirection.Bottom:
 					_swipeGesture.Edge = Fuse.Gestures.Edge.Bottom;
+					_swipeGesture.HitSize = 10;
 					break;
 			}
 		}


### PR DESCRIPTION
Reduce hit size of the edge detection. Now edge navigation will only triggered if you start to swipe really from the edge of the screen. (Previously it can be triggered up until 100pt from the edge)

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
