### PR TITLE
Single finger PanGesture

### DIFF
--- a/Source/Fuse.Gestures/Internal/TwoFinger.uno
+++ b/Source/Fuse.Gestures/Internal/TwoFinger.uno
@@ -29,6 +29,23 @@ namespace Fuse.Gestures.Internal
 		}
 
 		bool _allowKeyControl = true;
+		bool _allowSingleTouch = false;
+
+		/* used for pan gesture to enable translating element using just one finger */
+		public bool SingleTouch
+		{
+			get
+			{
+				return _allowSingleTouch;
+			}
+			set
+			{
+				if (value != _allowSingleTouch)
+				{
+					_allowSingleTouch = value;
+				}
+			}
+		}
 
 		static readonly PropertyHandle _property = Fuse.Properties.CreateHandle();
 		static public TwoFinger Attach(Visual n)
@@ -98,7 +115,7 @@ namespace Fuse.Gestures.Internal
 
 		GestureRequest IGesture.OnPointerPressed(PointerPressedArgs args)
 		{
-			if (_point[1].Down != -1)
+			if (_point[1].Down != -1 && !_allowSingleTouch)
 				return GestureRequest.Ignore;
 
 			return GestureRequest.Capture;
@@ -114,6 +131,8 @@ namespace Fuse.Gestures.Internal
 				else if (_point[1].Down != -1)
 					sig = Vector.Length( _point[0].Current - _point[0].Start ) +
 					Vector.Length( _point[1].Current - _point[1].Start );
+				else if (_point[1].Down == -1)
+					sig = Vector.Length( _point[0].Current - _point[0].Start );
 				return new GesturePriorityConfig( GesturePriority.Normal, sig );
 			}
 		}
@@ -202,6 +221,8 @@ namespace Fuse.Gestures.Internal
 				}*/
 
 			}
+			else if (_allowSingleTouch)
+				trans = _point[0].Current - _point[0].Start;
 			else if (_allowKeyControl)
 			{
 				if (Keyboard.IsKeyPressed(Uno.Platform.Key.ControlKey))
@@ -224,7 +245,6 @@ namespace Fuse.Gestures.Internal
 					_trackingKeyboard = true;
 				}
 			}
-
 			if (_begun)
 			{
 				if (Zoomed != null)

--- a/Source/Fuse.Gestures/PanGesture.uno
+++ b/Source/Fuse.Gestures/PanGesture.uno
@@ -24,9 +24,27 @@ namespace Fuse.Gestures
 			: base(target)
 		{ }
 
+		bool _allowSingleTouch = true;
+		public bool SingleTouch
+		{
+			get
+			{
+				return _allowSingleTouch;
+			}
+			set
+			{
+				if (value != _allowSingleTouch)
+				{
+					_allowSingleTouch = value;
+					Impl.SingleTouch = _allowSingleTouch;
+				}
+			}
+		}
+
 		protected override void OnRooted()
 		{
 			base.OnRooted();
+			Impl.SingleTouch = _allowSingleTouch;
 			Impl.Translated += OnTranslated;
 		}
 


### PR DESCRIPTION
Currently, `PanGesture` (part of `TransformGesture`) to translate an `Element` only works with two-finger and that is not intuitive. With this PR we can do a `PanGesture` with both one or two fingers.

### Example:

```
<App>
    <JavaScript>
        module.exports = {
            url : 'https://images.unsplash.com/photo-1633493894963-3dfe3149fcdb?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=987&q=80'
        }
    </JavaScript>
    <ClientPanel Color="White">
        <Panel HitTestMode="LocalBounds">
            <Image Url="{url}">
                <InteractiveTransform ux:Name="ImageTrans"/>
            </Image>
            <ZoomGesture Target="ImageTrans"/>
            <PanGesture Target="ImageTrans"/>
            <RotateGesture Target="ImageTrans"/>
        </Panel>
    </ClientPanel>
</App>
```

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
