### PR TITLE
iOS: fix MetalAngle compile errors

### DIFF
--- a/Source/Fuse.Common/GraphicsWorker.uno
+++ b/Source/Fuse.Common/GraphicsWorker.uno
@@ -7,6 +7,7 @@ using Fuse;
 namespace Fuse
 {
 	[extern(ANDROID) Require("Source.Include", "Uno/Graphics/GLHelper.h")]
+	[extern(IOS && METAL) Require("Source.Include", "MetalANGLE/MGLKit.h")]
 	/** Allows dispatching actions on a separate thread with access to a grpahics
 		context that shares data with the main graphics context of the @App.
 		This is for example used to do asynchronous loading of textures.
@@ -41,13 +42,21 @@ namespace Fuse
 		[Foreign(Language.ObjC)]
 		extern(iOS) static ObjC.Object CreateContext()
 		@{
+		#if @(METAL:Defined)
+			return [[MGLContext alloc] initWithAPI:kMGLRenderingAPIOpenGLES2 sharegroup:[MGLContext currentContext].sharegroup];
+		#else
 			return [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2 sharegroup:[EAGLContext currentContext].sharegroup];
+		#endif
 		@}
 
 		[Foreign(Language.ObjC)]
 		extern(iOS) static void SetCurrentContext(ObjC.Object context)
 		@{
+		#if @(METAL:Defined)
+			[MGLContext setCurrentContext: context];
+		#else
 			[EAGLContext setCurrentContext: context];
+		#endif
 		@}
 
 		static void Start()

--- a/Source/Fuse.Controls.CameraView/iOS/NativePhoto.uno
+++ b/Source/Fuse.Controls.CameraView/iOS/NativePhoto.uno
@@ -238,11 +238,15 @@ namespace Fuse.Controls.iOS
 			CVOpenGLESTextureRef textureHandle;
 			CVOpenGLESTextureCacheRef textureCacheHandle;
 
+		#if @(METAL:Defined)
+			U_ERROR("NativePhoto: Not supported on Metal");
+		#else
 			#if COREVIDEO_USE_EAGLCONTEXT_CLASS_IN_API
 			CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, [EAGLContext currentContext], NULL, &textureCacheHandle);
 			#else
 			CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, (__bridge void *)[EAGLContext currentContext], NULL, &textureCacheHandle);
 			#endif
+		#endif
 
 			if (err != kCVReturnSuccess) {
 				onReject([NSString stringWithFormat:@"Failed to create CVOpenGLESTextureCache, error code: %d", err]);

--- a/Source/Fuse.Controls.Native/NativeRenderer.uno
+++ b/Source/Fuse.Controls.Native/NativeRenderer.uno
@@ -104,11 +104,12 @@ namespace Fuse.Controls.Native
 		}
 
 		[Foreign(Language.ObjC)]
-		[Require("Xcode.Framework", "GLKit")]
+		[extern(!METAL) Require("Xcode.Framework", "GLKit")]
 		[Require("Source.Include", "UIKit/UIKit.h")]
 		[Require("Source.Include", "CoreGraphics/CoreGraphics.h")]
-		[Require("Source.Include", "GLKit/GLKit.h")]
-		[Require("Source.Include", "OpenGLES/EAGL.h")]
+		[extern(!METAL) Require("Source.Include", "GLKit/GLKit.h")]
+		[extern(!METAL) Require("Source.Include", "OpenGLES/EAGL.h")]
+		[extern(METAL) Require("Source.Include","OpenGLES/ES2/gl.h")]
 		[Require("Source.Include", "QuartzCore/QuartzCore.h")]
 		extern(iOS)
 		static void Upload(

--- a/Source/Fuse.Controls.Native/iOS/Helpers.h
+++ b/Source/Fuse.Controls.Native/iOS/Helpers.h
@@ -4,8 +4,13 @@
 
 #include <Uno/Uno.h>
 #include <UIKit/UIKit.h>
+#if @(METAL:Defined)
+#include <MetalANGLE/MGLKit.h>
+#else
 #include <GLKit/GLKit.h>
 #include <OpenGLES/EAGL.h>
+#endif
+
 
 @interface ShapeView : UIControl
 -(UIControl*)childrenView;

--- a/Source/Fuse.Controls.Video/iOS/VideoImpl.mm
+++ b/Source/Fuse.Controls.Video/iOS/VideoImpl.mm
@@ -127,11 +127,15 @@ namespace FuseVideoImpl
 		if (errorCallback != NULL)
 			uRetain(errorCallback);
 
+	#if @(METAL:Defined)
+		U_ERROR("VideoImpl: Not supported on Metal");
+	#else
 		#if COREVIDEO_USE_EAGLCONTEXT_CLASS_IN_API
 		CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, [EAGLContext currentContext], NULL, &(vs->TextureCacheHandle));
 		#else
 		CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, (__bridge void *)[EAGLContext currentContext], NULL, &(vs->TextureCacheHandle));
 		#endif
+	#endif
 
 		NSURL * url = [NSURL URLWithString:uri];
 

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
@@ -17,7 +17,7 @@ namespace Fuse.Drawing
 
 	[Require("Xcode.Framework","CoreGraphics")]
 	[Require("Source.Include", "CoreGraphics/CoreGraphicsLib.h")]
-	[Require("Xcode.Framework","GLKit")]
+	[extern(!METAL) Require("Xcode.Framework","GLKit")]
 	[extern(iOS) Require("Source.Include","OpenGLES/ES2/gl.h")]
 	extern(iOS||OSX)
 	abstract class CoreGraphicsSurface : Surface

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
@@ -11,7 +11,7 @@ namespace Fuse.Drawing
 {
 	[Require("Xcode.Framework","CoreGraphics")]
 	[Require("Source.Include", "CoreGraphics/CoreGraphicsLib.h")]
-	[Require("Xcode.Framework","GLKit")]
+	[extern(!METAL) Require("Xcode.Framework","GLKit")]
 	[extern(OSX) Require("Source.Include","XliPlatform/GL.h")]
 	[extern(iOS) Require("Source.Include","OpenGLES/ES2/gl.h")]
 	extern(iOS||OSX)

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "android": "uno build android Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",
     "android-emu": "uno build android-emu Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",
     "dotnet": "uno build dotnet Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",
-    "ios": "uno build ios Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",
+    "ios": "uno build ios Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --debug",
+    "ios-metal": "uno build ios Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj -DMETAL --debug",
     "ios-sim": "uno build ios-sim Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",
+    "ios-sim-metal": "uno build ios-sim Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj -DMETAL --run",
     "native": "uno build native Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj --run",
     "doc-export": "uno build docs tools/doc-export"
   },


### PR DESCRIPTION
This fixes compile errors and enables building using -DMETAL.

The -DMETAL flag was introduced in https://github.com/fuse-open/uno/pull/396.

Apps are crashing so it looks like more work is needed to support
MetalANGLE in Fuselibs.

Closes #1432