### PR TITLE
Introduce Fuse.Shortcut

### DIFF
--- a/Source/Fuse.Shortcut/Fuse.Shortcut.unoproj
+++ b/Source/Fuse.Shortcut/Fuse.Shortcut.unoproj
@@ -1,0 +1,17 @@
+{
+  "Copyright": "Copyright (c) Fuse Open 2022",
+  "Description": "Shows menu items when pressing App Icon on the device home screen",
+  "Publisher": "Fuse Open",
+  "Packages": [
+    "Uno.Threading"
+  ],
+  "Projects": [
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Common/Fuse.Common.unoproj",
+  ],
+  "Includes": [
+    "*",
+    "iOS/FOShortcutHandler.h:ObjCHeader:iOS",
+    "iOS/FOShortcutHandler.m:ObjCSource:iOS",
+  ]
+}

--- a/Source/Fuse.Shortcut/ShortcutModule.uno
+++ b/Source/Fuse.Shortcut/ShortcutModule.uno
@@ -1,0 +1,96 @@
+using Uno;
+using Uno.UX;
+using Uno.Threading;
+using Fuse;
+using Fuse.Scripting;
+
+namespace Fuse.Shortcut
+{
+	/**
+		@scriptmodule FuseJS/Shortcut
+
+		This module allows you to shows menu items when pressing App Icon on the device home screen.
+		This feature refer to the [home screen actions](https://developer.apple.com/design/human-interface-guidelines/ios/system-capabilities/home-screen-actions/) on iOS and [App Shortcut](https://developer.android.com/guide/topics/ui/shortcuts.html) on Android (introduced in Android 7.1 / API Level 25).
+
+		You need to add a reference to `"Fuse.Shortcut"` in your project file to use this feature.
+
+		This module is an @EventEmitter, so the methods from @EventEmitter can be used to listen to events.
+
+		## Usage
+
+		The following example shows how create shortcut:
+		```xml
+				<App>
+					<JavaScript>
+
+						var Observable = require("FuseJS/Observable")
+						var selectedShortcut = new Observable("-")
+
+						var shortcut = require("FuseJS/Shortcut");
+						shortcut.registerShortcuts([
+							{
+								id: 'compose',
+								title: "Compose",
+								icon: "assets/images/compose.png"
+							},
+							{
+								id: 'profile',
+								title: "Profile",
+								icon: "assets/images/user.png"
+							},
+							{
+								id: 'book_store',
+								title: "Book Store",
+								icon: "assets/images/book.png"
+							}
+						])
+
+						shortcut.on('shortcutClicked', (type) => {
+							selectedShortcut.value = type;
+						})
+
+						module.exports = {
+							selectedShortcut
+						}
+
+					</JavaScript>
+					<StackPanel Margin="20">
+						<Text Value="Selected Shortcut: {selectedShortcut}" />
+					</StackPanel>
+				</App>
+
+		Note that on the `registerShortcuts` method accepts array of json objects with the following properties:
+		* id, id of the shortcut, and will be passed on the `shortcutClicked` callback when particular shortcut get clicked. This property is mandatory
+		* title, to display menu title. This property is mandatory
+		* subtitle, to display sub title (displayed below the title on iOS). This property is optional
+		* icon, to display icon beside the menu title, value of the icon is a local image path (i.e asset path) not a url and must be registered as a Bundle. More info about Bundle [here.](/docs/assets/bundle). This property is optional
+	*/
+	[UXGlobalModule]
+	public class ShortcutModule : NativeEventEmitterModule
+	{
+		static readonly ShortcutModule _instance;
+		public ShortcutModule() : base(true, "shortcutClicked")
+		{
+			if(_instance != null) return;
+			Resource.SetGlobalKey(_instance = this, "FuseJS/Shortcut");
+
+			AddMember(new NativeFunction("registerShortcuts", RegisterShortcuts));
+		}
+
+		object RegisterShortcuts(Context c, object[] args)
+		{
+			if (args.Length > 0)
+			{
+				var shortcuts = Json.Stringify(args[0]);
+				ShortcutProvider.RegisterShortcuts(shortcuts, MenuClicked);
+			}
+			return null;
+		}
+
+		void MenuClicked(string shortcutType)
+		{
+			Emit("shortcutClicked", shortcutType);
+		}
+
+	}
+}

--- a/Source/Fuse.Shortcut/ShortcutProvider.uno
+++ b/Source/Fuse.Shortcut/ShortcutProvider.uno
@@ -1,0 +1,167 @@
+using Uno;
+using Uno.IO;
+using Uno.Compiler.ExportTargetInterop;
+using Uno.Collections;
+
+namespace Fuse.Shortcut
+{
+	[ForeignInclude(Language.Java, "android.annotation.TargetApi", "android.os.Build", "android.content.pm.ShortcutInfo","android.content.pm.ShortcutManager", "android.content.Intent", "android.content.Context", "android.app.Activity", "android.content.res.AssetManager", "android.graphics.drawable.Icon")]
+	[ForeignInclude(Language.ObjC, "iOS/FOShortcutHandler.h")]
+	[Require("AppDelegate.SourceFile.Declaration", "#include <iOS/FOShortcutHandler.h>")]
+	[Require("AppDelegate.SourceFile.DidFinishLaunchingWithOptions", "return [[FOShortcutHandler sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];")]
+	[Require("AppDelegate.SourceFile.ImplementationScope", "- (void)applicationDidBecomeActive:(UIApplication *)application { uAutoReleasePool pool; [[FOShortcutHandler sharedInstance] applicationDidBecomeActive:application]; }")]
+	[Require("AppDelegate.SourceFile.ImplementationScope", "- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL succeeded))completionHandler { uAutoReleasePool pool; [[FOShortcutHandler sharedInstance] application:application performActionForShortcutItem:shortcutItem completionHandler:completionHandler]; }")]
+	public class ShortcutProvider
+	{
+
+		public static void RegisterShortcuts(string shortcuts, Action<string> callback)
+		{
+			if defined(iOS)
+				RegisterIOSShortcuts(deserialize(shortcuts), callback);
+			if defined(Android)
+				RegisterAndroidShortcuts(deserialize(shortcuts), callback);
+		}
+
+		[Foreign(Language.ObjC)]
+		extern(iOS) static ObjC.Object deserialize(string shortcuts)
+		@{
+			NSMutableArray * arrShortcuts = [[NSMutableArray alloc] init];
+			arrShortcuts = [NSJSONSerialization JSONObjectWithData: [shortcuts dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:nil];
+			for (NSMutableDictionary* item in arrShortcuts)
+			{
+				if (item[@"icon"] != nil)
+				{
+					NSString * path = @{GetBundlePath(string):Call(item[@"icon"])};
+					item[@"icon"] = [@"data/" stringByAppendingString:path];
+				}
+			}
+			return arrShortcuts;
+		@}
+
+		[Foreign(Language.Java)]
+		extern(Android) static Java.Object deserialize(string shortcuts)
+		@{
+			java.util.List<java.util.Map> listShortcuts = new java.util.ArrayList<>();
+			try
+			{
+				org.json.JSONArray jsonArray = new org.json.JSONArray(shortcuts.trim());
+				for (int i = 0; i < jsonArray.length(); i++)
+				{
+					Object jsonArrayValue = jsonArray.get(i);
+					if (jsonArrayValue instanceof org.json.JSONObject) {
+						java.util.Map<String, String> map = new java.util.HashMap<>();
+						org.json.JSONObject jsonObject = (org.json.JSONObject)jsonArrayValue;
+						java.util.Iterator<String> keys = jsonObject.keys();
+						while(keys.hasNext())
+						{
+							String keyStr = keys.next();
+							String keyValue = (String)jsonObject.get(keyStr);
+							map.put(keyStr, keyValue);
+						}
+						listShortcuts.add(map);
+					}
+				}
+			}
+			catch (org.json.JSONException je) {
+				je.printStackTrace();
+			}
+			return listShortcuts;
+		@}
+
+		[Foreign(Language.ObjC)]
+		extern(iOS) static void RegisterIOSShortcuts(ObjC.Object data, Action<string> callback)
+		@{
+			[[FOShortcutHandler sharedInstance] registerShortcuts:(NSArray*)data];
+			[[FOShortcutHandler sharedInstance] registerCallback:callback];
+		@}
+
+		[Foreign(Language.Java)]
+		extern(Android) static void RegisterAndroidShortcuts(Java.Object data, Action<string> callback)
+		@{
+			// Do nothing for anything lower than API 25 as the functionality isn't supported.
+			if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) {
+				return;
+			}
+
+			com.fuse.Activity.IntentListener l = new com.fuse.Activity.IntentListener() {
+				@Override public void onIntent(android.content.Intent data) {
+					if (data.hasExtra("com.fuse.shortcut"))
+					{
+						String type = data.getStringExtra("com.fuse.shortcut");
+						if (callback != null)
+							callback.run(type);
+					}
+				}
+			};
+			com.fuse.Activity.subscribeToIntents(l, Intent.ACTION_RUN);
+
+			final Activity context = com.fuse.Activity.getRootActivity();
+			final String packageName = context.getPackageName();
+			final AssetManager assets = context.getAssets();
+			final java.util.List<ShortcutInfo> shortcutInfos = new java.util.ArrayList<>();
+
+			java.util.List<java.util.Map<String, String>> shortcuts = (java.util.List<java.util.Map<String, String>>)data;
+			for (java.util.Map<String, String> shortcut : shortcuts) {
+				final String icon = shortcut.get("icon");
+				final String type = shortcut.get("id");
+				final String title = shortcut.get("title");
+				final String subtitle = shortcut.get("subtitle");
+
+				final ShortcutInfo.Builder shortcutBuilder = new ShortcutInfo.Builder(context, type);
+				if (icon != null)
+				{
+					String path = @{GetBundlePath(string):Call(icon)};
+					if (path != "")
+					{
+						android.graphics.Bitmap bitmap = null;
+						try
+						{
+							java.io.InputStream stream = assets.open(path);
+							bitmap = android.graphics.BitmapFactory.decodeStream(stream);
+							stream.close();
+							shortcutBuilder.setIcon(Icon.createWithBitmap(bitmap));
+						}
+						catch (Exception e)
+						{
+							e.printStackTrace();
+						}
+					}
+				}
+				Intent intent = context.getPackageManager().getLaunchIntentForPackage(packageName).setAction(Intent.ACTION_RUN).putExtra("com.fuse.shortcut", type).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+				final ShortcutInfo shortcutInfo = shortcutBuilder.setLongLabel(subtitle == null ? title : subtitle).setShortLabel(title).setIntent(intent).build();
+				shortcutInfos.add(shortcutInfo);
+			}
+
+			context.runOnUiThread(new Runnable() {
+				@Override
+				@TargetApi(Build.VERSION_CODES.N_MR1)
+				public void run() {
+					ShortcutManager shortcutManager = (ShortcutManager) context.getSystemService(Context.SHORTCUT_SERVICE);
+					try {
+						shortcutManager.removeAllDynamicShortcuts();
+						shortcutManager.setDynamicShortcuts(shortcutInfos);
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				}
+			});
+		@}
+
+		public static string GetBundlePath(string path)
+		{
+			BundleFile bundleFile = null;
+			foreach(var bf in Uno.IO.Bundle.AllFiles)
+			{
+				if(bf.SourcePath == path)
+				{
+					bundleFile = bf;
+					break;
+				}
+			}
+			if (bundleFile != null)
+				return bundleFile.BundlePath;
+			else
+				return "";
+		}
+	}
+}

--- a/Source/Fuse.Shortcut/iOS/FOShortcutHandler.h
+++ b/Source/Fuse.Shortcut/iOS/FOShortcutHandler.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+@interface FOShortcutHandler : NSObject
+
++(instancetype)sharedInstance;
+
+@property (nonatomic, copy) void (^_onCallback)(NSString* shortcutType);
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
+- (void)applicationDidBecomeActive:(UIApplication *)application;
+- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL succeeded))completionHandler;
+
+-(void)registerShortcuts:(NSArray*)shortcuts;
+-(void)registerCallback:(void (^)(NSString* shortcutType))_onCallback;
+-(void)handleShortcut:(NSString*)type;
+@end

--- a/Source/Fuse.Shortcut/iOS/FOShortcutHandler.m
+++ b/Source/Fuse.Shortcut/iOS/FOShortcutHandler.m
@@ -1,0 +1,82 @@
+#import "FOShortcutHandler.h"
+
+@interface FOShortcutHandler ()
+@property(nonatomic, retain) NSString *shortcutType;
+@property(nonatomic, assign) BOOL _pendingCall;
+@end
+
+@implementation FOShortcutHandler
+
+static FOShortcutHandler * instance = nil;
+
+@synthesize _onCallback;
+
++(instancetype)sharedInstance
+{
+    if (instance == nil)
+        instance = [[FOShortcutHandler alloc] init];
+    return instance;
+}
+
+-(void)registerCallback:(void (^)(NSString* shortcutType))_onCallback
+{
+    self._onCallback = _onCallback;
+    if (self._pendingCall)
+        [self handleShortcut:self.shortcutType];
+}
+
+-(void)registerShortcuts:(NSArray*)shortcuts
+{
+
+     NSMutableArray<UIApplicationShortcutItem *> *newShortcuts = [[NSMutableArray alloc] init];
+
+    for (NSDictionary* item in shortcuts)
+    {
+        UIApplicationShortcutIcon *icon = nil;
+        if (item[@"icon"] != nil)
+            icon = [UIApplicationShortcutIcon iconWithTemplateImageName:item[@"icon"]];
+        UIApplicationShortcutItem *shortcut = [[UIApplicationShortcutItem alloc] initWithType:item[@"id"] localizedTitle:item[@"title"] localizedSubtitle:item[@"subtitle"] icon:icon userInfo:nil];
+        [newShortcuts addObject:shortcut];
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [UIApplication sharedApplication].shortcutItems = @[];
+        [UIApplication sharedApplication].shortcutItems = newShortcuts;
+    });
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    UIApplicationShortcutItem *shortcutItem = launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
+    if (shortcutItem)
+    {
+        self.shortcutType = shortcutItem.type;
+        return NO;
+    }
+    return YES;
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    if (self.shortcutType) {
+        [self handleShortcut:self.shortcutType];
+    }
+}
+
+- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL succeeded))completionHandler
+{
+    [self handleShortcut:shortcutItem.type];
+}
+
+-(void)handleShortcut:(NSString*)type
+{
+    if (self._onCallback != nil)
+    {
+        self._onCallback(type);
+        self._pendingCall = NO;
+        self.shortcutType = nil;
+    }
+    else
+        self._pendingCall = YES;
+}
+@end


### PR DESCRIPTION
This module allows you to shows menu items when pressing App Icon on the device home screen. This feature refers to the [home screen actions](https://developer.apple.com/design/human-interface-guidelines/ios/system-capabilities/home-screen-actions/) on iOS and [App Shortcut](https://developer.android.com/guide/topics/ui/shortcuts.html) on Android (introduced in Android 7.1 / API Level 25)

## Example
```
<App>
	<JavaScript>

		var Observable = require("FuseJS/Observable")
		var selectedShortcut = new Observable("-")

		var shortcut = require("FuseJS/Shortcut");
		shortcut.registerShortcuts([
			{
				id: 'compose',
				title: "Compose",
				icon: "assets/images/compose.png"
			},
			{
				id: 'profile',
				title: "Profile",
				icon: "assets/images/user.png"
			},
			{
				id: 'book_store',
				title: "Book Store",
				icon: "assets/images/book.png"
			}
		])

		shortcut.on('shortcutClicked', (type) => {
			selectedShortcut.value = type;
		})

		module.exports = {
			selectedShortcut
		}

	</JavaScript>
	<StackPanel Margin="20">
		<Text Value="Selected Shortcut: {selectedShortcut}" />
	</StackPanel>
</App>
```

please add `Fuse.Shortcut` to your Uno Project

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
