### PR TITLE
Fix memory leak on glass effect

### DIFF
--- a/Source/Fuse.Controls.Primitives/Behaviors/Glass.uno
+++ b/Source/Fuse.Controls.Primitives/Behaviors/Glass.uno
@@ -277,7 +277,13 @@ namespace Fuse.Effects
 				DepthTestEnabled: false;
 			};
 
+			FramebufferPool.Release(original);
+			FramebufferPool.Release(blurRegion);
 			FramebufferPool.Release(blur);
+
+			original = null;
+			blurRegion = null;
+			blur = null;
 		}
 	}
 }


### PR DESCRIPTION
Fixed memory leak where the framebuffer after the capture region operation is not released

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
