### PR TITLE
Feature: Dashed Strokes

### DIFF
--- a/Source/Fuse.Drawing/Brushes/DashedColor.uno
+++ b/Source/Fuse.Drawing/Brushes/DashedColor.uno
@@ -1,0 +1,84 @@
+using Uno;
+using Uno.Collections;
+using Uno.Collections.EnumerableExtensions;
+using Uno.Graphics;
+using Uno.UX;
+using Fuse.Drawing;
+using Fuse;
+
+namespace Fuse.Drawing
+{
+	public sealed class DashedColor : DynamicBrush
+	{
+		static Selector _colorName = "Color";
+		static Selector _dashedSizeName = "DashedSize";
+
+		public DashedColor()
+		{
+			_color = float4(1);
+		}
+
+		public DashedColor(float4 color, float dashedSize)
+		{
+			_color = color;
+			_dashedSize = dashedSize;
+		}
+
+		float4 _color;
+		public float4 Color
+		{
+			get { return _color; }
+			set
+			{
+				if (_color != value)
+				{
+					_color = value;
+					OnPropertyChanged(_colorName);
+				}
+			}
+		}
+
+		float _dashedSize = 0;
+		public float DashedSize
+		{
+			get { return _dashedSize; }
+			set
+			{
+				if(_dashedSize != value)
+				{
+					_dashedSize = value;
+					OnPropertyChanged(_dashedSizeName);
+				}
+			}
+		}
+
+		public override bool IsCompletelyTransparent { get { return base.IsCompletelyTransparent || Color.W == 0; } }
+
+		static float Box(float2 p, float2 b)
+		{
+			float2 d = Math.Abs(p) - b;
+			return Math.Min( Math.Max(d.X, d.Y), 0.0f) + Vector.Length(Math.Max(d, 0.0f));
+		}
+
+		static float2 Rep(float2 p, float2 c)
+		{
+			return Math.Mod(p, c) - 0.5f * c;
+		}
+
+		float2 p: req(TexCoord as float2) pixel TexCoord.XY * CanvasSize.XY;
+		float t:
+		{
+			float2 nRep = CanvasSize.XY / DashedSize;
+			int2 iRep = (int2)nRep;
+			if(Math.Mod(iRep.X, 2) == 0)
+				++iRep.X;
+			if(Math.Mod(iRep.Y, 2) == 0)
+				++iRep.Y;
+
+			nRep = CanvasSize.XY / (float2)iRep;
+			float t = Box( Rep(p, nRep * 2) + float2(DashedSize), float2(DashedSize) );
+			return -Math.Floor(t);
+		};
+		FinalColor: Math.Lerp(float4(0), Color, Math.Clamp(t, 0.f, 1.f));
+	}
+}

--- a/Source/Fuse.Drawing/Stroke.uno
+++ b/Source/Fuse.Drawing/Stroke.uno
@@ -28,6 +28,40 @@ namespace Fuse.Drawing
 				OnPropertyChanged(_shadingName);
 		}
 
+		static Selector _dashedSizeName = "DashedSize";
+		[UXOriginSetter("SetDashedSize")]
+		/**
+			Create a dashed stroke and set the gap between stroke.
+		*/
+		public float DashedSize
+		{
+			get
+			{
+				if (Brush is DashedColor)
+					return ((DashedColor)Brush).DashedSize;
+				return 0.0f;
+			}
+			set
+			{
+				SetDashedSize(value, this);
+			}
+		}
+
+		public void SetDashedSize(float dashedSize, IPropertyListener origin)
+		{
+			if (dashedSize != DashedSize && dashedSize > 0)
+			{
+				if (!(Brush is DashedColor))
+					Brush = new DashedColor(Color, dashedSize);
+				else
+					((DashedColor)Brush).DashedSize = dashedSize;
+			}
+			else
+				Brush = new SolidColor(Color);
+
+			OnPropertyChanged(_dashedSizeName, origin);
+		}
+
 		static Selector _brushName = "Brush";
 		Brush _brush;
 		[UXContent]
@@ -60,7 +94,7 @@ namespace Fuse.Drawing
 		/**
 			The color of the stroke.
 
-		 	For more information on what notations Color supports, check out [this subpage](articles:ux-markup/literals#colors).
+			For more information on what notations Color supports, check out [this subpage](articles:ux-markup/literals#colors).
 		*/
 		public float4 Color
 		{
@@ -68,6 +102,8 @@ namespace Fuse.Drawing
 			{
 				if (Brush is ISolidColor)
 					return ((ISolidColor)Brush).Color;
+				if (Brush is DashedColor)
+					return ((DashedColor)Brush).Color;
 				return float4(0);
 			}
 			set
@@ -79,12 +115,22 @@ namespace Fuse.Drawing
 		{
 			if (color != Color)
 			{
-				if (!(Brush is SolidColor))
- 					Brush = new SolidColor(color);
-	 			else
-	 				((SolidColor)Brush).Color = color;
+				if (DashedSize > 0)
+				{
+					if (!(Brush is DashedColor))
+						Brush = new DashedColor(Color, DashedSize);
+					else
+						((DashedColor)Brush).Color = color;
+				}
+				else
+				{
+					if (!(Brush is SolidColor))
+						Brush = new SolidColor(color);
+					else
+						((SolidColor)Brush).Color = color;
+				}
 
-	 			OnPropertyChanged(_colorName, origin);
+				OnPropertyChanged(_colorName, origin);
 			}
 		}
 


### PR DESCRIPTION
Added experimental support for drawing dashed strokes using the new `DashedSize` property on the `Stroke` class

### Example:
```
<Rectangle Size=300 Color="Yellow">
    <Stroke Width="5" DashedSize="10" Color="Red" />
</Rectangle>
```
This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
