### PR TITLE
Fuse.Text: silence C warning on Mac

### DIFF
--- a/Source/Fuse.Text/icu/i18n/unicode/uconfig.h
+++ b/Source/Fuse.Text/icu/i18n/unicode/uconfig.h
@@ -15,6 +15,9 @@
 #ifndef __UCONFIG_H__
 #define __UCONFIG_H__
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 /*!
  * \file


### PR DESCRIPTION
This silences warnings from uconfig.h seen when building on Mac with
Xcode 13.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
