### PR TITLE
WebView (Android): Image picker dialog

### DIFF
--- a/Source/Fuse.Controls.WebView/Android/PickImage.uxl
+++ b/Source/Fuse.Controls.WebView/Android/PickImage.uxl
@@ -1,0 +1,24 @@
+<Extensions Backend="CPlusPlus" Condition="ANDROID">
+
+    <!-- Used to implement onShowFileChooser() in FuseWebChromeClient.java -->
+
+    <Require Gradle.Dependency.Implementation="com.github.jrvansuita:PickImage:2.5.5" />
+
+    <Require Gradle.AllProjects.Repository="maven { url 'https://jitpack.io' }" />
+
+    <Require AndroidManifest.ApplicationElement>
+        <![CDATA[
+        <provider
+            android:name="com.vansuita.pickimage.provider.PickImageFileProvider"
+            android:authorities="${applicationId}.com.vansuita.pickimage.provider"
+            android:exported="false"
+            android:grantUriPermissions="true"
+            tools:replace="android:authorities">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/picker_provider_paths" />
+        </provider>
+        ]]>
+    </Require>
+
+</Extensions>


### PR DESCRIPTION
Show a dialog to let us choose either Camera or Gallery to pick an image
to upload, unless multiple files are allowed (not supported).

* Extract _filePathCallback and onReceiveFileChooserValue(), so we can
  finish the existing callback to avoid a dead-lock.

* Integrate PickImage by vansuita via UXL.

~~Depends on https://github.com/fuse-open/uno/pull/409 and https://github.com/fuse-open/uno/pull/412.~~

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
