### PR TITLE
Make WebView more friendly for wrapping a web app

### DIFF
--- a/Source/Fuse.Controls.WebView/Android/WebViewForeign.uno
+++ b/Source/Fuse.Controls.WebView/Android/WebViewForeign.uno
@@ -20,6 +20,7 @@ namespace Fuse.Android.Controls.WebViewUtils
 			wv.getSettings().setLoadWithOverviewMode(true); //mimic iOS Safari and Android Chrome
 			wv.getSettings().setSupportZoom(zoomEnabled);
 			wv.getSettings().setBuiltInZoomControls(zoomEnabled);
+			wv.getSettings().setDisplayZoomControls(false);
 			wv.getSettings().setDomStorageEnabled(true);
 			wv.setAllowScroll(scrollEnabled);
 

--- a/Source/Fuse.Controls.WebView/iOS/WebView.uno
+++ b/Source/Fuse.Controls.WebView/iOS/WebView.uno
@@ -54,6 +54,8 @@ namespace Fuse.iOS.Controls
 			WKWebView* wv = [[WKWebView alloc] init];
 			wv.scrollView.delegate = zoomEnabled ? NULL : [[NoZoomDelegate alloc] init];
 			wv.scrollView.scrollEnabled = scrollEnabled;
+			wv.allowsBackForwardNavigationGestures = YES;
+			wv.allowsLinkPreview = NO;
 
 			return wv;
 		@}


### PR DESCRIPTION
On iOS by enabling edge swipe for history back, and disabling preview a page on long pressing a link, and on Android by hiding zoom button controls

**note**:
This is hard code by means that currently, this PR is not introducing the public property of `WebView` to change the behavior, maybe will do on separate PR. 

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
