### PR TITLE
Prevent duplicate paths in iOS

### DIFF
--- a/Source/Fuse.ImageTools/iOS/ImageHelper.m
+++ b/Source/Fuse.ImageTools/iOS/ImageHelper.m
@@ -354,7 +354,8 @@
 		temp:(BOOL)temp
 {
 	NSString* name = [[url path] lastPathComponent];
-	return [NSString stringWithFormat:@"%@/%@", [self createImagePath:temp], name];
+	NSString* uuid = [[NSUUID UUID] UUIDString];
+	return [NSString stringWithFormat:@"%@/%@%@", [self createImagePath:temp], uuid, name];
 }
 
 +(NSString*) applicationDocumentsDirectory


### PR DESCRIPTION
When photos are edited in iOS and I get them via camera roll return me the same path for both. This modification adds a unique uuid for each path avoiding the error