### PR TITLE
Fuse.LocalNotifications: Android 12 compatibility fix

### DIFF
--- a/Source/Fuse.LocalNotifications/Android/Impl.uxl
+++ b/Source/Fuse.LocalNotifications/Android/Impl.uxl
@@ -1,7 +1,7 @@
 <Extensions Backend="CPlusPlus" Condition="Android">
     <ProcessFile Name="LocalNotificationReceiver.java" TargetName="@(Java.SourceDirectory)/com/fuse/LocalNotifications/LocalNotificationReceiver.java" />
     <Require AndroidManifest.ApplicationElement><![CDATA[
-        <receiver android:name="com.fuse.LocalNotifications.LocalNotificationReceiver">
+        <receiver android:name="com.fuse.LocalNotifications.LocalNotificationReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.media.action.DISPLAY_NOTIFICATION" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Add the android:exported attribute to silence the following error when targetting Android 12 (API 31):

    Apps targeting Android 12 and higher are required to specify an
    explicit value for `android:exported` when the corresponding
    component has an intent filter defined. [...]

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
