### PR TITLE
Fuse.Controls.WebView: upgrade com.github.jrvansuita:PickImage

### DIFF
--- a/Source/Fuse.Controls.WebView/Android/PickImage.uxl
+++ b/Source/Fuse.Controls.WebView/Android/PickImage.uxl
@@ -2,7 +2,7 @@
 
     <!-- Used to implement onShowFileChooser() in FuseWebChromeClient.java -->
 
-    <Require Gradle.Dependency.Implementation="com.github.jrvansuita:PickImage:2.5.5" />
+    <Require Gradle.Dependency.Implementation="com.github.jrvansuita:PickImage:3.0.01" />
 
     <Require Gradle.AllProjects.Repository="maven { url 'https://jitpack.io' }" />
 


### PR DESCRIPTION
This upgrades PickImage for Android to version 3.0.01 (latest).

The new major version requires API 31 to build successfully, which was introduced in Uno version 2.5.0.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
