### PR TITLE
Fuse.Scripting: add Context.Stringify()

### DIFF
--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -100,6 +100,15 @@ namespace Fuse.Scripting
 			return null;
 		}
 
+		Function _stringify;
+		public string Stringify(object value)
+		{
+			if (_stringify == null)
+				_stringify = (Function)Evaluate("(Context)", "JSON.stringify");
+
+			return _stringify.Call(this, value).ToString();
+		}
+
 		Function _parseJson;
 		public object ParseJson(string json)
 		{


### PR DESCRIPTION
This method converts a JavaScript object to a Uno string containing a JSON object, essentially invoking JSON.stringify() in JavaScript.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
