### PR TITLE
Fix desktop implementation of UserSettings Module

### DIFF
--- a/Source/Fuse.Common/Json.uno
+++ b/Source/Fuse.Common/Json.uno
@@ -26,6 +26,35 @@ namespace Fuse
 			else if (value is float) sb.Append(ToLiteral((double)(float)value));
 			else if (value is int) sb.Append(ToLiteral((double)(int)value));
 			else if (value is bool) sb.Append(ToLiteral((bool)value));
+			else if (value is IDictionary<string, object>)
+			{
+				if (visitedSet.Contains(value))
+					throw new Exception("Json.Stringify(): object can not contain cycles");
+
+				visitedSet.Add(value);
+				var obj = value as IDictionary<string, object>;
+				sb.Append("{");
+				var keys = new string[obj.Keys.Count];
+				var enumKeys = obj.Keys.GetEnumerator();
+				var idx = 0;
+				while (enumKeys.MoveNext())
+				{
+					keys[idx] = enumKeys.Current;
+					idx++;
+				}
+				if (normalized) Uno.Array.Sort(keys, String.Compare);
+				for (int i = 0; i < keys.Length; i++)
+				{
+					if (i > 0) sb.Append(",");
+					ToLiteral(keys[i], sb);
+					sb.Append(":");
+					Stringify(obj[keys[i]], normalized, sb, visitedSet);
+				}
+
+				sb.Append("}");
+
+				visitedSet.Remove(value);
+			}
 			else if (value is IObject)
 			{
 				if (visitedSet.Contains(value))

--- a/Source/Fuse.Storage/UserSettingsImpl.uno
+++ b/Source/Fuse.Storage/UserSettingsImpl.uno
@@ -8,18 +8,31 @@ namespace Fuse.Storage
 {
 	public extern(!MOBILE) class DesktopUserSettingsImpl
 	{
-		static readonly string filename = "UserSettings.json";
 		static DesktopUserSettingsImpl instance;
 		static Dictionary<string, object> data = new Dictionary<string, object>();
 
+		static string GetFilename()
+		{
+			string folder = @(Project.Name);
+			string filename = "UserSettings.json";
+			var settingFolder = Path.Combine(Directory.GetUserDirectory(UserDirectory.Data), folder);
+			var settingFile = Path.Combine(settingFolder, filename);
+
+			if (!Directory.Exists(settingFolder))
+				Directory.CreateDirectory(settingFolder);
+			if (!File.Exists(settingFile))
+				using(var stream = File.Open(settingFile, FileMode.Create)) {}
+
+			return settingFile;
+		}
+
 		private DesktopUserSettingsImpl()
 		{
-			string content = "";
-			ApplicationDir.TryRead(filename, out content);
+			string content = File.ReadAllText(DesktopUserSettingsImpl.GetFilename());
 			if (content != "") {
 				IObject obj = Json.Parse(content) as IObject;
 				for (var i = 0; i< obj.Keys.Length; i++)
-				 	data[obj.Keys[i]] = obj[obj.Keys[i]];
+					data[obj.Keys[i]] = obj[obj.Keys[i]];
 			}
 		}
 
@@ -94,7 +107,7 @@ namespace Fuse.Storage
 		private void Synchronize()
 		{
 			var jsonString = Json.Stringify(data);
-			ApplicationDir.Write(filename, jsonString);
+			File.WriteAllText(DesktopUserSettingsImpl.GetFilename(), jsonString);
 		}
 	}
 

--- a/Source/Fuse.Storage/UserSettingsModule.uno
+++ b/Source/Fuse.Storage/UserSettingsModule.uno
@@ -35,7 +35,7 @@ namespace Fuse.Storage
 					'married': false
 				});
 
-				var username = userSettings.getString('username');
+				var email = userSettings.getString('email');
 				var password = userSettings.getString('password');
 				var api_token = userSettings.getString('api_token');
 				var logged = userSettings.getBoolean('logged');


### PR DESCRIPTION
Currently broken on desktop (NET) because:
- There is no `Json.Stringify` for `Dictionary` object (the implementation is using `Dictionary` object and serialize it to json)
- Shared output file between Apps / Project, so it will overwrite the output between Apps/Project

This will fix those problems.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
