### PR TITLE
Fuse.PushNotifications: Android 12 compatibility fix (hotfix)

### DIFF
--- a/Source/Fuse.PushNotifications/Android/Impl.cpp.uxl
+++ b/Source/Fuse.PushNotifications/Android/Impl.cpp.uxl
@@ -7,7 +7,7 @@
 
     <Require AndroidManifest.ApplicationElement><![CDATA[
 
-        <service android:name="com.fuse.PushNotifications.PushNotificationReceiver">
+        <service android:name="com.fuse.PushNotifications.PushNotificationReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             </intent-filter>


### PR DESCRIPTION
Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
