### PR TITLE
Fuse.Scripting: deprecate NativePromise without Context (beta-3.0)

### DIFF
--- a/Source/Fuse.Alerts/NativeAlerts.uno
+++ b/Source/Fuse.Alerts/NativeAlerts.uno
@@ -60,7 +60,7 @@ namespace Fuse.Alerts
 
 			@return (Promise) A boolean promise that resolves to `true` if the OK button was pressed.
 		*/
-		public static Future<bool> Alert(object[] args)
+		static Future<bool> Alert(Context context, object[] args)
 		{
 			return AlertInternal(
 				getOrDefault(args, 0, "Alert!"),
@@ -80,7 +80,7 @@ namespace Fuse.Alerts
 
 			@return (Promise) A boolean promise that resolves to `true` if the OK button was pressed and `false` if the Cancel button was pressed.
 		*/
-		public static Future<bool> Confirm(object[] args)
+		static Future<bool> Confirm(Context context, object[] args)
 		{
 			return ConfirmInternal(
 				getOrDefault(args, 0, "Confirm"),

--- a/Source/Fuse.Auth/BiometricModule.uno
+++ b/Source/Fuse.Auth/BiometricModule.uno
@@ -72,7 +72,7 @@ namespace Fuse
 			return supported;
 		}
 
-		static Future<BiometricStatus> Authenticate(object[] args)
+		static Future<BiometricStatus> Authenticate(Context c, object[] args)
 		{
 			if (args.Length != 1)
 				throw new Exception("authenticate() requires exactly 1 parameter.");

--- a/Source/Fuse.Auth/SignInModule.uno
+++ b/Source/Fuse.Auth/SignInModule.uno
@@ -74,7 +74,7 @@ namespace Fuse
 			AddMember(new NativePromise<LoginInformation, Scripting.Object>("signIn", SignIn, Converter));
 		}
 
-		static Future<bool> HasSignedIn(object[] args)
+		static Future<bool> HasSignedIn(Context context, object[] args)
 		{
 			var p = new Promise<bool>();
 			if defined (iOS)
@@ -84,7 +84,7 @@ namespace Fuse
 			return p;
 		}
 
-		static Future<LoginInformation> SignIn(object[] args)
+		static Future<LoginInformation> SignIn(Context context, object[] args)
 		{
 			var p = new Promise<LoginInformation>();
 			if defined (iOS)

--- a/Source/Fuse.Camera/Camera.uno
+++ b/Source/Fuse.Camera/Camera.uno
@@ -48,7 +48,7 @@ namespace Fuse.Camera
 			Starts an OS-specific image capture view and returns a Promise of the resulting Image.
 
 			If the desiredWidth and height parameters are set, returns an Image scaled as close to the specified
-			width/height as possible while maintaining aspect ratio. 
+			width/height as possible while maintaining aspect ratio.
 
 			If no size parameters are given, the taken image will be full-sized as determined by the device camera.
 
@@ -59,7 +59,7 @@ namespace Fuse.Camera
 
 			@return (Promise) a Promise of a device-orientation-corrected read/writable Image.
 		*/
-		static Future<Image> TakePictureInterface(object[] args)
+		static Future<Image> TakePictureInterface(Context context, object[] args)
 		{
 			if(args.Length==0) return TakePicture();
 			var width = args.ValueOrDefault<int>(0);
@@ -98,7 +98,7 @@ namespace Fuse.Camera
 
 			@return (Promise) a Promise that resolves if the user has permission
 		*/
-		static Future<string> CheckUserPermissions(object[] args)
+		static Future<string> CheckUserPermissions(Context context, object[] args)
 		{
 			var p = new Promise<string>();
 			if defined(Android)
@@ -115,7 +115,7 @@ namespace Fuse.Camera
 
 			@return (Promise) a Promise that resolves after the user has granted permissions
 		*/
-		static Future<string> RequestUserPermissions(object[] args) 
+		static Future<string> RequestUserPermissions(Context context, object[] args)
 		{
 			var p = new Promise<string>();
 			if defined(Android)

--- a/Source/Fuse.CameraRoll/CameraRoll.uno
+++ b/Source/Fuse.CameraRoll/CameraRoll.uno
@@ -68,7 +68,7 @@ namespace Fuse.CameraRoll
 
 			@return (Promise) a Promise of a local read/writable Image copied from the camera roll.
 		*/
-		static Future<Image> SelectPictureInterface(object[] args)
+		static Future<Image> SelectPictureInterface(Context context, object[] args)
 		{
 			return SelectPicture();
 		}
@@ -88,7 +88,7 @@ namespace Fuse.CameraRoll
 
 			@return (Promise) a Promise that resolves to `true` when/if the publish completed
 		*/
-		static Future<bool> AddToCameraRollInterface(object[] args)
+		static Future<bool> AddToCameraRollInterface(Context context, object[] args)
 		{
 			var Image = Image.FromObject(args[0]);
 			return AddToCameraRoll(Image);
@@ -101,7 +101,7 @@ namespace Fuse.CameraRoll
 
 			@return (Promise) a Promise that resolves if the user has permission
 		*/
-		static Future<string> CheckUserPermissions(object[] args)
+		static Future<string> CheckUserPermissions(Context context, object[] args)
 		{
 			var p = new Promise<string>();
 			if defined(Android)
@@ -118,7 +118,7 @@ namespace Fuse.CameraRoll
 
 			@return (Promise) a Promise that resolves after the user has granted permissions
 		*/
-		static Future<string> RequestUserPermissions(object[] args) 
+		static Future<string> RequestUserPermissions(Context context, object[] args) 
 		{
 			var p = new Promise<string>();
 			if defined(Android)

--- a/Source/Fuse.FileSystem/FileSystemModule.uno
+++ b/Source/Fuse.FileSystem/FileSystemModule.uno
@@ -123,7 +123,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<Nothing> AppendTextToFile(object[] args)
+		Future<Nothing> AppendTextToFile(Context context, object[] args)
 		{
 			var path = GetPathFromArgs(args);
 			var text = GetArg<string>(args, 1, "Second argument \"text\" is required to be a string");
@@ -173,7 +173,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		public Future<Nothing> CreateDirectory(object[] args)
+		Future<Nothing> CreateDirectory(Context context, object[] args)
 		{
 			return _operations.CreateDirectory(GetPathFromArgs(args));
 		}
@@ -192,7 +192,7 @@ namespace Fuse.FileSystem
 				FileSystem.createDirectory(FileSystem.dataDirectory + "/" + "new-directory");
 			```
 		*/
-		public object CreateDirectorySync(Context context, object[] args)
+		object CreateDirectorySync(Context context, object[] args)
 		{
 			_operations.CreateDirectorySync(GetPathFromArgs(args));
 			return null;
@@ -219,7 +219,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<Nothing> Remove(object[] args)
+		Future<Nothing> Remove(Context context, object[] args)
 		{
 			var recursive = (args.Length > 1 && args[1] is bool) ? (bool)args[1] : false;
 			return _operations.Delete(GetPathFromArgs(args), recursive);
@@ -267,7 +267,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<bool> Exists(object[] args)
+		Future<bool> Exists(Context context, object[] args)
 		{
 			return _operations.Exists(GetPathFromArgs(args));
 		}
@@ -373,7 +373,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<FileSystemInfo> GetDirectoryInfo(object[] args)
+		Future<FileSystemInfo> GetDirectoryInfo(Context context, object[] args)
 		{
 			return _operations.GetDirectoryInfo(GetPathFromArgs(args));
 		}
@@ -435,7 +435,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<FileSystemInfo> GetFileInfo(object[] args)
+		Future<FileSystemInfo> GetFileInfo(Context context, object[] args)
 		{
 			return _operations.GetFileInfo(GetPathFromArgs(args));
 		}
@@ -511,7 +511,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<string[]> ListDirectories(object[] args)
+		Future<string[]> ListDirectories(Context context, object[] args)
 		{
 			return _operations.ListDirectories(GetPathFromArgs(args));
 		}
@@ -557,7 +557,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<string[]> ListEntries(object[] args)
+		Future<string[]> ListEntries(Context context, object[] args)
 		{
 			return _operations.ListEntries(GetPathFromArgs(args));
 		}
@@ -603,7 +603,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<string[]> ListFiles(object[] args)
+		Future<string[]> ListFiles(Context context, object[] args)
 		{
 			return _operations.ListFiles(GetPathFromArgs(args));
 		}
@@ -651,7 +651,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<Nothing> Move(object[] args)
+		Future<Nothing> Move(Context context, object[] args)
 		{
 			var source = GetArg<string>(args, 0, "First argument `source` has to be a valid path");
 			var destination = GetArg<string>(args, 1, "Second argument `destination` has to be a valid path");
@@ -703,7 +703,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<Nothing> Copy(object[] args)
+		Future<Nothing> Copy(Context context, object[] args)
 		{
 			var source = GetArg<string>(args, 0, "First argument `source` has to be a valid path");
 			var destination = GetArg<string>(args, 1, "Second argument `destination` has to be a valid path");
@@ -753,7 +753,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<byte[]> ReadBufferFromFile(object[] args)
+		Future<byte[]> ReadBufferFromFile(Context context, object[] args)
 		{
 			return _operations.ReadBufferFromFile(GetPathFromArgs(args));
 		}
@@ -798,7 +798,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<string> ReadTextFromFile(object[] args)
+		Future<string> ReadTextFromFile(Context context, object[] args)
 		{
 			return _operations.ReadTextFromFile(GetPathFromArgs(args));
 		}
@@ -849,7 +849,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<Nothing> WriteBufferToFile(object[] args)
+		Future<Nothing> WriteBufferToFile(Context context, object[] args)
 		{
 			var path = GetPathFromArgs(args);
 			var data = GetArg<byte[]>(args, 1, "Second argument \"data\" is required to be an ArrayBuffer");
@@ -904,7 +904,7 @@ namespace Fuse.FileSystem
 					});
 			```
 		*/
-		Future<Nothing> WriteTextToFile(object[] args)
+		Future<Nothing> WriteTextToFile(Context context, object[] args)
 		{
 			var path = GetPathFromArgs(args);
 			var text = GetArg<string>(args, 1, "Second argument \"text\" is required to be a string");

--- a/Source/Fuse.GeoLocation/GeoLocation.uno
+++ b/Source/Fuse.GeoLocation/GeoLocation.uno
@@ -336,7 +336,7 @@ namespace Fuse.GeoLocation
 			```
 			See [the GeoLocation module](api:fuse/geolocation/geolocation) for an example.
 		*/
-		Future<Fuse.GeoLocation.Location> GetLocationAsync(object[] args)
+		Future<Fuse.GeoLocation.Location> GetLocationAsync(Context c, object[] args)
 		{
 			double timeout = (args.Length > 0) ? Marshal.ToDouble(args[0]) : 20000;
 			return _locationTracker.GetLocationAsync(timeout);

--- a/Source/Fuse.ImageTools/ImageTools.uno
+++ b/Source/Fuse.ImageTools/ImageTools.uno
@@ -101,7 +101,7 @@ namespace Fuse.ImageTools
 					then(function (image) { console.log("Scratch image path is: " + image.path); });
 			```
 		*/
-		Future<Image> ImageFromBufferInterface(object[] args)
+		Future<Image> ImageFromBufferInterface(Context c, object[] args)
 		{
 			var p = new Promise<Image>();
 			var cb = new ImagePromiseCallback(p);
@@ -149,7 +149,7 @@ namespace Fuse.ImageTools
 					.then(function(buf) { console.log("Image contains " + buf.byteLength + " bytes"); });
 			```
 		*/
-		Future<byte[]> BufferFromImageInterface(object[] args)
+		Future<byte[]> BufferFromImageInterface(Context c, object[] args)
 		{
 			var p = new Promise<byte[]>();
 			if(args.Length == 1){
@@ -206,7 +206,7 @@ namespace Fuse.ImageTools
 					.then(function(newImage) { console.log("Path of resized image is " + newImage.path); });
 			```
 		*/
-		Future<Image> ResizeImageInterface(object[] args)
+		Future<Image> ResizeImageInterface(Context c, object[] args)
 		{
 			if(args.Length!=2)
 				throw new Exception("resize takes 2 arguments: An Image and an Object of options");
@@ -253,7 +253,7 @@ namespace Fuse.ImageTools
 					.then(function(newImage) { console.log("Path of cropped image is " + newImage.path); });
 			```
 		*/
-		Future<Image> CropImageInterface(object[] args)
+		Future<Image> CropImageInterface(Context c, object[] args)
 		{
 			if(args.Length!=2)
 				throw new Exception("crop takes 2 arguments: An Image and an options object");
@@ -298,7 +298,7 @@ namespace Fuse.ImageTools
 					});
 			```
 		*/
-		Future<Image> ImageFromBase64Interface(object[] args)
+		Future<Image> ImageFromBase64Interface(Context c, object[] args)
 		{
 			if(args.Length!=1)
 				throw new Exception("imageFromBase64 needs a base64 string argument");
@@ -321,7 +321,7 @@ namespace Fuse.ImageTools
 					.then(function(base64Image) { console.log("The base64 encoded image is \"" + base64Image + "\""); });
 			```
 		*/
-		Future<string> Base64FromImageInterface(object[] args)
+		Future<string> Base64FromImageInterface(Context c, object[] args)
 		{
 			if(args.Length!=1)
 				throw new Exception("base64FromImage needs a Image argument");

--- a/Source/Fuse.MediaPicker/MediaPickerModule.uno
+++ b/Source/Fuse.MediaPicker/MediaPickerModule.uno
@@ -67,7 +67,7 @@ namespace Fuse.MediaPicker
 
 			@return (Promise) a Promise of images path array.
 		*/
-		static Future<string> PickImageInterface(object[] args)
+		static Future<string> PickImageInterface(Context context, object[] args)
 		{
 			var arguments = args[0] as Scripting.Object;
 			var p = new Promise<string>();
@@ -102,7 +102,7 @@ namespace Fuse.MediaPicker
 
 			@return (Promise) a Promise of a video path.
 		*/
-		static Future<string> PickVideoInterface(object[] args)
+		static Future<string> PickVideoInterface(Context context, object[] args)
 		{
 			var arguments = args[0] as Scripting.Object;
 

--- a/Source/Fuse.Scripting/NativePromise.uno
+++ b/Source/Fuse.Scripting/NativePromise.uno
@@ -3,8 +3,10 @@ using Uno.Threading;
 
 namespace Fuse.Scripting
 {
+	[Obsolete("Please use ResultFactory2 instead.")]
 	public delegate T ResultFactory<T>(object[] args);
 	public delegate T ResultFactory2<T>(Context context, object[] args);
+	[Obsolete("Please use FutureFactory2 instead.")]
 	public delegate Future<T> FutureFactory<T>(object[] args);
 	public delegate Future<T> FutureFactory2<T>(Context context, object[] args);
 	public delegate TJSResult ResultConverter<T, TJSResult>(Context context, T result);
@@ -46,6 +48,7 @@ namespace Fuse.Scripting
 		ResultConverter<T, TJSResult> _resultConverter;
 		ResultFactory2<T> _func;
 
+		[Obsolete("Please add the Context parameter to your delegate.")]
 		public NativePromise(string name, ResultFactory<T> func, ResultConverter<T, TJSResult> resultConverter = null): base(name)
 		{
 			_func = new ResultFactoryClosure<T>(func).Run;
@@ -67,6 +70,7 @@ namespace Fuse.Scripting
 			return future;
 		}
 
+		[Obsolete("Please add the Context parameter to your delegate.")]
 		public NativePromise(string name, FutureFactory<T> futureFactory, ResultConverter<T, TJSResult> resultConverter = null): base(name)
 		{
 			_futureFactory = new FutureFactoryClosure<T>(futureFactory).Run;

--- a/Source/Fuse.Storage/StorageModule.uno
+++ b/Source/Fuse.Storage/StorageModule.uno
@@ -55,7 +55,7 @@ namespace Fuse.Storage
 					});
 			```
 		*/
-		static Future<bool> WriteAsync(object[] args)
+		static Future<bool> WriteAsync(Context c, object[] args)
 		{
 			if (args.Length > 0)
 			{
@@ -86,7 +86,7 @@ namespace Fuse.Storage
 			```
 			
 		*/
-		static Future<string> ReadAsync(object[] args)
+		static Future<string> ReadAsync(Context c, object[] args)
 		{
 			if (args.Length > 0)
 			{
@@ -117,7 +117,7 @@ namespace Fuse.Storage
 
 			> Warning: This call will block until the operation is finished.
 		*/
-		static object Remove(Scripting.Context c, object[] args)
+		static object Remove(Context c, object[] args)
 		{
 			if (args.Length > 0)
 			{
@@ -148,7 +148,7 @@ namespace Fuse.Storage
 
 			> Warning: This call will block until the operation is finished. Use write() if you are writing large amounts of data.
 		*/
-		static object Write(Scripting.Context c, object[] args)
+		static object Write(Context c, object[] args)
 		{
 			if (args.Length > 0)
 			{
@@ -176,7 +176,7 @@ namespace Fuse.Storage
 			
 			> Warning: This call will block until the operation is finished. Use read() if you are reading large amounts of data.
 		*/
-		static object Read(Scripting.Context c, object[] args)
+		static object Read(Context c, object[] args)
 		{
 			string filename = null;
 			if (args.Length > 0)

--- a/Source/FuseJS/Bundle.uno
+++ b/Source/FuseJS/Bundle.uno
@@ -51,7 +51,7 @@ namespace FuseJS
 			});
 			```
 		*/
-		public static Future<byte[]> ReadBuffer(object[] args)
+		static Future<byte[]> ReadBuffer(Context c, object[] args)
 		{
 			var searchPath = args.ValueOrDefault<string>(0, "");
 			if(searchPath=="")
@@ -84,7 +84,7 @@ namespace FuseJS
 			});
 			```
 		*/
-		public static Future<IEnumerable<BundleFile>> GetList(object[] args = null)
+		static Future<IEnumerable<BundleFile>> GetList(Context c, object[] args)
 		{
 			var p = new Promise<IEnumerable<BundleFile>>();
 			var files = Uno.IO.Bundle.AllFiles;
@@ -133,7 +133,7 @@ namespace FuseJS
 			});
 			```
 		*/
-		public static Future<string> Extract(object[] args)
+		static Future<string> Extract(Context c, object[] args)
 		{
 			var searchPath = args.ValueOrDefault<string>(0, "");
 			var destinationPath = args.ValueOrDefault<string>(1, "");
@@ -164,7 +164,7 @@ namespace FuseJS
 			});
 			```
 		*/
-		public static Future<string> ReadAsync(object[] args)
+		static Future<string> ReadAsync(Context c, object[] args)
 		{
 			if (args.Length > 0)
 			{
@@ -213,7 +213,7 @@ namespace FuseJS
 			}
 			catch(Exception e)
 			{
-				return ""; // HACK!!
+				return "";
 			}
 		}
 

--- a/Source/FuseJS/FileReader.uno
+++ b/Source/FuseJS/FileReader.uno
@@ -40,13 +40,13 @@ namespace FuseJS
 			AddMember(new NativePromise<string, string>("readAsText", readAsText, null));
 		}
 
-		static Future<string> readAsDataURL(object[] args)
+		static Future<string> readAsDataURL(Context c, object[] args)
 		{
 			var path = (string)args[0];
 			return Promise<string>.Run(new FileReadCommand(path).ReadAsDataURL);
 		}
 
-		static Future<string> readAsText(object[] args)
+		static Future<string> readAsText(Context c, object[] args)
 		{
 			var path = (string)args[0];
 			return Promise<string>.Run(new FileReadCommand(path).ReadAsText);

--- a/Source/FuseJS/Globals.uno
+++ b/Source/FuseJS/Globals.uno
@@ -12,10 +12,10 @@ namespace FuseJS
 		{
 			if(_instance != null) return;
 			Resource.SetGlobalKey(_instance = this, "FuseJS/Globals");
-			AddMember(new NativePromise<string, string>("readAsText", (ResultFactory<string>)readAsText, null));
+			AddMember(new NativePromise<string, string>("readAsText", (ResultFactory2<string>)readAsText, null));
 		}
 
-		static string readAsText(object[] args)
+		static string readAsText(Context c, object[] args)
 		{
 			if (args.Length != 1) throw new Exception("Globals.readAsText(): Exactly one argument expected");
 


### PR DESCRIPTION
Make all existing instances of NativePromise receive the Context parameter, and deprecate the old constructors and delegate types.