### PR TITLE
Fuse.Scripting.JavaScript: TypeScript and transpiler support (beta-3.0)

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScript.uno
@@ -1,16 +1,16 @@
-//using Uno;
 using Uno.UX;
 using Uno.Collections;
 using Uno.Compiler;
 using Fuse.Scripting;
 using Uno.Testing;
 using Uno.Threading;
-using Fuse.Reactive;
 
 namespace Fuse.Reactive
 {
 	/**
 		The `JavaScript` tag is used to run JavaScript and assigns its `module.exports` as data context for the parent visual.
+
+		Use `Transpile="true"` to enable modern JavaScript features by transpiling user-provided code to ECMAScript 5.1.
 
 		**Note:** ECMAScript 5.1 is the only JavaScript version that is supported across all platforms.
 		While newer JavaScript features might work on some devices, this can't be guaranteed (particularly for earlier iOS versions).
@@ -154,6 +154,12 @@ namespace Fuse.Reactive
 					_scriptModule.Code = value;
 				}
 			}
+		}
+
+		/** Whether the UX compiler should transpile the code. This enables support for modern JavaScript features. */
+		public bool Transpile
+		{
+			get; set;
 		}
 
 		[UXLineNumber]

--- a/Source/Fuse.Scripting.JavaScript/TypeScript.uno
+++ b/Source/Fuse.Scripting.JavaScript/TypeScript.uno
@@ -1,0 +1,31 @@
+using Uno.UX;
+
+namespace Fuse.Reactive
+{
+	/**
+		The `TypeScript` tag is used to run TypeScript code.
+
+		The TypeScript code will be transpiled to JavaScript by the UX compiler
+		(located in Uno) before running the app.
+
+		## Example
+
+		```typescript
+		<TypeScript>
+			const line: string = "Hello, TypeScript!"
+			console.log(line)
+		</TypeScript>
+		```
+
+		@topic JavaScript
+	*/
+	public class TypeScript : JavaScript
+	{
+		[UXConstructor]
+		public TypeScript([UXAutoNameTable] NameTable nameTable)
+			: base(nameTable)
+		{
+			Transpile = true;
+		}
+	}
+}


### PR DESCRIPTION
This adds a new TypeScript tag and a new Transpile attribute on the existing JavaScript tag, used to enable modern script features.

The UX compiler (located in Uno) will understand these and invoke the FuseJS transpiler accordingly, replacing user-provided code (modern) with transpiled code (ES5) compatible with our JavaScript engine.

The live reload feature in Fuse X will understand these also, transpiling user-provided code to ES5 on the fly.