### PR TITLE
Fuse.Drawing.Surface: update assembly references for .NET 6.0 (beta-3.0)

### DIFF
--- a/Source/Fuse.Drawing.Surface/DotNet.uxl
+++ b/Source/Fuse.Drawing.Surface/DotNet.uxl
@@ -1,4 +1,4 @@
 <Extensions Backend="CIL">
-    <Require Assembly="System.Drawing" />
-    <Require Assembly="System.Windows.Forms" />
+	<Require Assembly="System.Drawing.Common/lib/net6.0/System.Drawing.Common.dll" />
+	<Require Condition="HOST_WINDOWS" Assembly="System.Windows.Forms" />
 </Extensions>

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -121,8 +121,7 @@ namespace Fuse.Drawing
 		}
 	}
 
-	[Require("Assembly", "System.Drawing")]
-	[extern(DOTNET) Require("Source.Include","XliPlatform/GL.h")]
+	[extern(DOTNET) Require("Source.Include", "XliPlatform/GL.h")]
 	extern(DOTNET)
 	internal class DotNetSurface : Surface
 	{
@@ -996,7 +995,6 @@ namespace Fuse.Drawing
 
 	namespace DotNetNative
 	{
-
 		[DotNetType("System.Drawing.Imaging.ImageFormat")]
 		extern(DOTNET) internal class ImageFormat
 		{
@@ -1072,7 +1070,6 @@ namespace Fuse.Drawing
 			public override extern void Dispose();
 		}
 
-
 		[DotNetType("System.Drawing.Drawing2D.LinearGradientBrush")]
 		extern(DOTNET) internal class LinearGradientBrush : DotNetBrush
 		{
@@ -1097,7 +1094,6 @@ namespace Fuse.Drawing
 			public extern Color[] SurroundColors { get; set; }
 			public override extern void Dispose();
 		}
-
 
 		[DotNetType("System.Drawing.SolidBrush")]
 		extern(DOTNET) internal class SolidBrush : DotNetBrush
@@ -1137,7 +1133,6 @@ namespace Fuse.Drawing
 			// constructors
 			public extern BitmapData();
 
-
 			// properties
 			public extern int Height { get; set; }
 			public extern PixelFormat PixelFormat { get; set; }
@@ -1145,7 +1140,6 @@ namespace Fuse.Drawing
 			public extern int Stride { get; set; }
 			public extern int Width { get; set; }
 		}
-
 
 		[DotNetType("System.Drawing.Graphics")]
 		extern(DOTNET) internal class DotNetGraphics
@@ -1258,7 +1252,6 @@ namespace Fuse.Drawing
 			public extern byte G { get; }
 			public extern byte B { get; }
 
-
 			public static extern Color Blue { get; }
 			public static extern Color Black { get; }
 			public static extern Color Orange { get; }
@@ -1295,7 +1288,6 @@ namespace Fuse.Drawing
 		{
 			// constructors
 			public extern PointF(float x, float y);
-
 
 			// properties
 			public extern bool IsEmpty { get; }
@@ -1343,7 +1335,6 @@ namespace Fuse.Drawing
 			public extern Pen(DotNetBrush b, float width);
 			public extern Pen(Color c);
 			public extern Pen(Color c, float width);
-
 
 			// properties
 			public extern DotNetBrush Brush { get; set; }

--- a/Source/Fuse.Drawing.Surface/System.Drawing.Common.stuff
+++ b/Source/Fuse.Drawing.Surface/System.Drawing.Common.stuff
@@ -1,0 +1,3 @@
+if CIL {
+    System.Drawing.Common: "https://www.nuget.org/api/v2/package/System.Drawing.Common/6.0.0"
+}

--- a/Source/Fuse.ImageTools/DotNet.uxl
+++ b/Source/Fuse.ImageTools/DotNet.uxl
@@ -1,3 +1,3 @@
 <Extensions Backend="CIL">
-    <Require Assembly="System.Drawing" />
+	<Require Assembly="System.Drawing.Common/lib/net6.0/System.Drawing.Common.dll" />
 </Extensions>

--- a/Source/Fuse.ImageTools/DotNetImageUtils.uno
+++ b/Source/Fuse.ImageTools/DotNetImageUtils.uno
@@ -43,7 +43,6 @@ namespace Fuse.ImageTools
 
 	namespace DotNetNative
 	{
-		[Require("Assembly", "System.Drawing")]
 		[DotNetType("System.Drawing.Image")]
 		extern(DOTNET) internal class DotNetImage
 		{

--- a/Source/Fuse.ImageTools/System.Drawing.Common.stuff
+++ b/Source/Fuse.ImageTools/System.Drawing.Common.stuff
@@ -1,0 +1,3 @@
+if CIL {
+    System.Drawing.Common: "https://www.nuget.org/api/v2/package/System.Drawing.Common/6.0.0"
+}

--- a/Source/Fuse.Nodes/Tests/DrawRectsTest/DefineDrawRects.cil.uxl
+++ b/Source/Fuse.Nodes/Tests/DrawRectsTest/DefineDrawRects.cil.uxl
@@ -1,5 +1,4 @@
 <Extensions Backend="CIL">
     <Define FUSELIBS_DEBUG_DRAW_RECTS />
-
-    <Require Assembly="System.Windows.Forms" />
+    <Require Condition="HOST_WINDOWS" Assembly="System.Windows.Forms" />
 </Extensions>

--- a/Source/Fuse.Nodes/Tests/DrawRectsTest/DrawRects.Test.uno
+++ b/Source/Fuse.Nodes/Tests/DrawRectsTest/DrawRects.Test.uno
@@ -336,7 +336,7 @@ namespace DrawRectsTest
 			}
 		}
 
-		extern(DOTNET) static class MessagePumper
+		extern(DOTNET && HOST_WINDOWS) static class MessagePumper
 		{
 			public static void PumpMessages()
 			{
@@ -344,7 +344,7 @@ namespace DrawRectsTest
 			}
 		}
 
-		extern(!DOTNET) static class MessagePumper
+		extern(!DOTNET || !HOST_WINDOWS) static class MessagePumper
 		{
 			public static void PumpMessages()
 			{
@@ -499,7 +499,7 @@ namespace DrawRectsTest
 	namespace DotNetNative
 	{
 		[DotNetType("System.Windows.Forms.Application")]
-		extern(DOTNET) public class Application
+		extern(DOTNET && HOST_WINDOWS) public class Application
 		{
 			public extern static void DoEvents();
 		}


### PR DESCRIPTION
* Download System.Drawing.Common@6.0.0 from NuGet
* Make System.Windows.Forms references conditional (Windows only)
