### PR TITLE
Push Notification: fix compatibility with latest Android

### DIFF
--- a/Source/Fuse.Android.Permissions/AndroidPermissionsInternal.uno
+++ b/Source/Fuse.Android.Permissions/AndroidPermissionsInternal.uno
@@ -769,5 +769,10 @@ namespace Fuse.Android.Permissions.Internal
         {
             return new PlatformPermission("android.permission.WRITE_VOICEMAIL");
         }
+        [TargetSpecificImplementation]
+        internal static extern PlatformPermission _post_notification()
+        {
+            return new PlatformPermission("android.permission.POST_NOTIFICATIONS");
+        }
     }
 }

--- a/Source/Fuse.Android.Permissions/AndroidPermissionsInternal.uxl
+++ b/Source/Fuse.Android.Permissions/AndroidPermissionsInternal.uxl
@@ -611,5 +611,9 @@
         <Method Signature="_write_voicemail():Fuse.Android.Permissions.PlatformPermission">
             <Require AndroidManifest.Permission="android.permission.WRITE_VOICEMAIL" />
         </Method>
+
+        <Method Signature="_post_notification():Fuse.Android.Permissions.PlatformPermission">
+            <Require AndroidManifest.Permission="android.permission.POST_NOTIFICATIONS" />
+        </Method>
     </Type>
 </Extensions>

--- a/Source/Fuse.Android.Permissions/Permissions.uno
+++ b/Source/Fuse.Android.Permissions/Permissions.uno
@@ -271,6 +271,7 @@ namespace Fuse.Android.Permissions
             public static PlatformPermission WRITE_SYNC_SETTINGS { get { return Internal.Android._write_sync_settings(); } }
             public static PlatformPermission WRITE_USER_DICTIONARY { get { return Internal.Android._write_user_dictionary(); } }
             public static PlatformPermission WRITE_VOICEMAIL { get { return Internal.Android._write_voicemail(); } }
+            public static PlatformPermission POST_NOTIFICATIONS { get { return Internal.Android._post_notification(); } }
         }
     }
 

--- a/Source/Fuse.Android.Permissions/Permissions.uxl
+++ b/Source/Fuse.Android.Permissions/Permissions.uxl
@@ -611,5 +611,9 @@
         <Method Signature="_write_voicemail():Fuse.Android.Permissions.PlatformPermission">
             <Require AndroidManifest.Permission="android.permission.WRITE_VOICEMAIL" />
         </Method>
+
+        <Method Signature="_post_notification():Fuse.Android.Permissions.PlatformPermission">
+            <Require AndroidManifest.Permission="android.permission.POST_NOTIFICATIONS" />
+        </Method>
     </Type>
 </Extensions>

--- a/Source/Fuse.PushNotifications/Android/PushNotificationReceiver.java
+++ b/Source/Fuse.PushNotifications/Android/PushNotificationReceiver.java
@@ -52,9 +52,9 @@ public class PushNotificationReceiver extends FirebaseMessagingService {
 
 				JSONObject jsonObj = new JSONObject(jsonStr);
 
-	            jsonStr = jsonObj.toString();
+				jsonStr = jsonObj.toString();
 
-	            bundle = jsonStrToBundle(jsonStr);
+				bundle = jsonStrToBundle(jsonStr);
 
 			} catch (JSONException je) {
 				Log.d("onMessageReceived", "BAD JSON");
@@ -69,87 +69,87 @@ public class PushNotificationReceiver extends FirebaseMessagingService {
 		}
 	}
 
-    public static Bundle jsonStrToBundle(String jsonStr) {
-        Bundle bundle = new Bundle();
+	public static Bundle jsonStrToBundle(String jsonStr) {
+		Bundle bundle = new Bundle();
 
-        try {
-            JSONObject jsonObject = new JSONObject(jsonStr.trim());
-            bundle = handleJSONObject(jsonObject);
-        } catch (JSONException notObject) {
-            try {
-                JSONArray jsonArr = new JSONArray(jsonStr.trim());
-                bundle = handleJSONArray(jsonArr);
-            } catch (JSONException badJSON) {
-                Log.d("jsonStrToBundle", "BAD JSON");
-            }
-        }
+		try {
+			JSONObject jsonObject = new JSONObject(jsonStr.trim());
+			bundle = handleJSONObject(jsonObject);
+		} catch (JSONException notObject) {
+			try {
+				JSONArray jsonArr = new JSONArray(jsonStr.trim());
+				bundle = handleJSONArray(jsonArr);
+			} catch (JSONException badJSON) {
+				Log.d("jsonStrToBundle", "BAD JSON");
+			}
+		}
 
-        return bundle;
-    }
+		return bundle;
+	}
 
 
-    public static Bundle handleJSONArray(JSONArray jsonArray) {
-        Bundle bundle = new Bundle();
+	public static Bundle handleJSONArray(JSONArray jsonArray) {
+		Bundle bundle = new Bundle();
 
-        for (int i = 0; i < jsonArray.length(); i++) {
+		for (int i = 0; i < jsonArray.length(); i++) {
 
-            try {
-                Object jsonArrayValue = jsonArray.get(i);
+			try {
+				Object jsonArrayValue = jsonArray.get(i);
 
-                if (jsonArrayValue instanceof JSONObject) {
-                    bundle.putBundle("" + i, handleJSONObject((JSONObject) jsonArrayValue));
-                } else if (jsonArrayValue instanceof JSONArray) {
-                    bundle.putBundle("" + i, handleJSONArray((JSONArray) jsonArrayValue));
-                } else if (jsonArrayValue instanceof String) {
-                    bundle.putString("" + i, "" + jsonArrayValue);
-                } else if (jsonArrayValue instanceof Boolean) {
-                    bundle.putBoolean("" + i, (boolean) jsonArrayValue);
-                } else if (jsonArrayValue instanceof Integer) {
-                    bundle.putInt("" + i, (int) jsonArrayValue);
-                } else if (jsonArrayValue instanceof Double) {
-                    bundle.putDouble("" + i, (double) jsonArrayValue);
-                } else if (jsonArrayValue instanceof Long) {
-                    bundle.putLong("" + i, (long) jsonArrayValue);
-                }
-            } catch (JSONException je) {
-                Log.d("handleJSONArray", "BAD JSON VALUE IN JSON ARRAY, AT POSITION: " + i);
-            }
-        }
+				if (jsonArrayValue instanceof JSONObject) {
+					bundle.putBundle("" + i, handleJSONObject((JSONObject) jsonArrayValue));
+				} else if (jsonArrayValue instanceof JSONArray) {
+					bundle.putBundle("" + i, handleJSONArray((JSONArray) jsonArrayValue));
+				} else if (jsonArrayValue instanceof String) {
+					bundle.putString("" + i, "" + jsonArrayValue);
+				} else if (jsonArrayValue instanceof Boolean) {
+					bundle.putBoolean("" + i, (boolean) jsonArrayValue);
+				} else if (jsonArrayValue instanceof Integer) {
+					bundle.putInt("" + i, (int) jsonArrayValue);
+				} else if (jsonArrayValue instanceof Double) {
+					bundle.putDouble("" + i, (double) jsonArrayValue);
+				} else if (jsonArrayValue instanceof Long) {
+					bundle.putLong("" + i, (long) jsonArrayValue);
+				}
+			} catch (JSONException je) {
+				Log.d("handleJSONArray", "BAD JSON VALUE IN JSON ARRAY, AT POSITION: " + i);
+			}
+		}
 
-        return bundle;
-    }
+		return bundle;
+	}
 
-    public static Bundle handleJSONObject(JSONObject jsonObject) {
-        Bundle bundle = new Bundle();
+	public static Bundle handleJSONObject(JSONObject jsonObject) {
+		Bundle bundle = new Bundle();
 
-        Iterator<String> keys = jsonObject.keys();
+		Iterator<String> keys = jsonObject.keys();
 
-        while(keys.hasNext()) {
-            String keyStr = keys.next();
+		while(keys.hasNext()) {
+			String keyStr = keys.next();
 
-            try {
-                Object keyValue = jsonObject.get(keyStr);
+			try {
+				Object keyValue = jsonObject.get(keyStr);
 
-                if (keyValue instanceof JSONObject) {
-                    bundle.putBundle(keyStr, handleJSONObject((JSONObject) keyValue));
-                } else if (keyValue instanceof JSONArray) {
-                    bundle.putBundle(keyStr, handleJSONArray((JSONArray) keyValue));
-                } else if (keyValue instanceof String) {
-                    bundle.putString(keyStr, "" + keyValue);
-                } else if (keyValue instanceof Boolean) {
-                    bundle.putBoolean(keyStr, (boolean) keyValue);
-                } else if (keyValue instanceof Integer) {
-                    bundle.putInt(keyStr, (int) keyValue);
-                } else if (keyValue instanceof Double) {
-                    bundle.putDouble(keyStr, (double) keyValue);
-                } else if (keyValue instanceof Long) {
-                    bundle.putLong(keyStr, (long) keyValue);
-                }
-            } catch (JSONException je) {
-                Log.d("handleJSONObject", "BAD JSON VALUE IN JSON OBJECT, AT KEY: " + keyStr);
-            }
-        }
+				if (keyValue instanceof JSONObject) {
+					bundle.putBundle(keyStr, handleJSONObject((JSONObject) keyValue));
+				} else if (keyValue instanceof JSONArray) {
+					bundle.putBundle(keyStr, handleJSONArray((JSONArray) keyValue));
+				} else if (keyValue instanceof String) {
+					bundle.putString(keyStr, "" + keyValue);
+				} else if (keyValue instanceof Boolean) {
+					bundle.putBoolean(keyStr, (boolean) keyValue);
+				} else if (keyValue instanceof Integer) {
+					bundle.putInt(keyStr, (int) keyValue);
+				} else if (keyValue instanceof Double) {
+					bundle.putDouble(keyStr, (double) keyValue);
+				} else if (keyValue instanceof Long) {
+					bundle.putLong(keyStr, (long) keyValue);
+				}
+			} catch (JSONException je) {
+				Log.d("handleJSONObject", "BAD JSON VALUE IN JSON OBJECT, AT KEY: " + keyStr);
+			}
+		}
 
-        return bundle;
-    }
+		return bundle;
+	}
 }

--- a/Source/Fuse.PushNotifications/Common.uno
+++ b/Source/Fuse.PushNotifications/Common.uno
@@ -12,14 +12,13 @@ namespace Fuse.PushNotifications
 
 	[ForeignInclude(Language.Java,
 		"android.util.Log",
-		"com.google.firebase.iid.FirebaseInstanceId",
 		"java.util.ArrayList",
 		"java.util.List",
 		"android.graphics.Color"
 	)]
 	[Require("Gradle.Dependency.ClassPath", "com.google.gms:google-services:4.3.2")]
 	[Require("Gradle.AllProjects.Repository", "maven {url 'https://maven.google.com'}")]
-	[Require("Gradle.Dependency.Implementation", "com.google.firebase:firebase-analytics:17.2.1")]
+	[Require("Gradle.Dependency.Implementation", "com.google.firebase:firebase-analytics:21.3.0")]
 	[Require("Gradle.BuildFile.End", "apply plugin: 'com.google.gms.google-services'")]
 	public static class PushNotify
 	{
@@ -165,7 +164,12 @@ namespace Fuse.PushNotifications
 			iOSImpl.RegisterForPushNotifications();
 		}
 
-		public extern(!iOS) static void Register() { }
+		public extern(Android) static void Register()
+		{
+			AndroidImpl.RegisterForPushNotifications();
+		}
+
+		public extern(!iOS && !Android) static void Register() { }
 
 		public extern(iOS) static bool IsRegisteredForRemoteNotifications()
 		{

--- a/Source/Fuse.PushNotifications/Docs/Guide.md
+++ b/Source/Fuse.PushNotifications/Docs/Guide.md
@@ -61,6 +61,11 @@ If you wish to disable auto-registration you can place the following in your uno
             "RegisterOnLaunch": false
         }
     },
+    "Android": {
+        "PushNotifications": {
+            "RegisterOnLaunch": false
+        }
+    },
 ```
 You must then register for push notifications by calling `register()` from JS. This option is useful as when the notifications are registered the OS may ask the user for permission to use push notifications and this may be undesirable on launch.
 

--- a/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
+++ b/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
@@ -12,7 +12,8 @@
     "../Fuse.Elements/Fuse.Elements.unoproj",
     "../Fuse.Platform/Fuse.Platform.unoproj",
     "../Fuse.Reactive/Fuse.Reactive.unoproj",
-    "../Fuse.Scripting/Fuse.Scripting.unoproj"
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Android.Permissions/Fuse.Android.Permissions.unoproj"
   ],
   "Includes": [
     "Docs/**:File",


### PR DESCRIPTION
We also needed this PR: https://github.com/fuse-open/uno/pull/504 to make it works

Now, on Android 13 later, we can lazy request permission for push notifications same with iOS. First, define it on the unoproj
```
"Android": {
  "PushNotifications": {
      "RegisterOnLaunch": false
    }
}
```

and in your App, you can call the `register` method to ask for permission. Example:
```
<App>
	<JavaScript>

		var push = require("FuseJS/Push");
		var Observable = require("FuseJS/Observable")

		var log = new Observable()

		push.on("registrationSucceeded", function(regID) {
			console.log("Reg Succeeded: " + regID);
			log.value = "Reg Succeeded: " + regID
		});

		push.on("error", function(reason) {
			console.log("Reg Failed: " + reason);
			log.value = "Reg Failed: " + reason
		});

		push.on("receivedMessage", function(payload) {
			console.log("Recieved Push Notification: " + payload);
			log.value = "Recieved Push Notification: " + payload
		});

		module.exports.log = log
		module.exports.register = function() {
			push.register()
		}

	</JavaScript>
	<ClientPanel>
		<StackPanel>
			<Text Value="{log}" />
			<Button Text="Register Notification" Clicked="{register}" />
		</StackPanel>
	</ClientPanel>
</App>
```

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests