### PR TITLE
Fuse.PushNotifications: remove AD_ID permission

### DIFF
--- a/Source/Fuse.PushNotifications/Android/RemoveAdvertisingId.uxl
+++ b/Source/Fuse.PushNotifications/Android/RemoveAdvertisingId.uxl
@@ -1,0 +1,7 @@
+<Extensions Backend="CPlusPlus" Condition="ANDROID && !ANDROID_AD_ID_PERMISSION">
+	<Require AndroidManifest.RootElement>
+		<![CDATA[
+			<uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+		]]>
+	</Require>
+</Extensions>

--- a/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
+++ b/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
@@ -27,6 +27,7 @@
 
     "Android/Impl.uno:Source",
     "Android/Impl.cpp.uxl:Extensions",
+    "Android/RemoveAdvertisingId.uxl:Extensions",
     "Android/PushNotificationReceiver.java:File",
     "Android/BigPictureStyleHttp.java:File",
     "Android/BundleFiles.java:File",


### PR DESCRIPTION
This removes the AD_ID permission from AndroidManifest to fix the following error when submitting an app in Google Play Console:

    This version includes the permission com.google.android.gms.permission.AD_ID,
    but your Play Console statement says that your app does not use the
    advertising ID.

The AD_ID permission was most likely introduced when upgrading firebase packages in 90b53e3.

Pass -DANDROID_AD_ID_PERMISSION to "uno build" if you wish to keep this permission in your AndroidManifest.