### PR TITLE
Fuse.Scripting.JavaScript: upgrade V8.Simple.net (beta-3.0)

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/V8/lib/DotNet.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/lib/DotNet.stuff
@@ -1,3 +1,3 @@
 if DOTNET && HOST_WINDOWS {
-/* 0.00MB */ DotNet: "https://www.nuget.org/api/v2/package/V8.Simple-dotnet/5.5.0"
+    DotNet: "https://www.nuget.org/api/v2/package/V8.Simple-dotnet/5.5.0-net6.0"
 }

--- a/Source/Fuse.Scripting.JavaScript/V8/lib/OSX.stuff
+++ b/Source/Fuse.Scripting.JavaScript/V8/lib/OSX.stuff
@@ -1,3 +1,3 @@
 if (DOTNET || NATIVE) && HOST_MAC {
-/* 7.81MB */ OSX: "https://www.nuget.org/api/v2/package/V8.Simple-macOS/5.5.0"
+    OSX: "https://www.nuget.org/api/v2/package/V8.Simple-macOS/5.5.0-net6.0"
 }


### PR DESCRIPTION
This upgrades V8.Simple.net assemblies (macOS and Windows) to .NET 6.0.