### PR TITLE
Fuse.Maps: com.google.android.gms:play-services-maps -> 17.0.0

### DIFF
--- a/Source/Fuse.Maps/Android/MapView.uno
+++ b/Source/Fuse.Maps/Android/MapView.uno
@@ -14,7 +14,7 @@ namespace Fuse.Maps.Android
 		MOVE = 2
 	}
 
-	[Require("Gradle.Dependency.Implementation", "com.google.android.gms:play-services-maps:16.1.0")]
+	[Require("Gradle.Dependency.Implementation", "com.google.android.gms:play-services-maps:17.0.0")]
 	extern (Android) public class MapView : Fuse.Controls.Native.Android.LeafView, IMapView
 	{
 		public bool IsReady { get; private set; }


### PR DESCRIPTION
This is the minimum version required to be published on Google Play.

Reported on Slack: https://fusecommunity.slack.com/archives/CGV5ZLY85/p1699546723472489