### PR TITLE
OS X -> macOS (beta-3.0)

### DIFF
--- a/Source/Fuse.Controls.Video/Video.uno
+++ b/Source/Fuse.Controls.Video/Video.uno
@@ -82,10 +82,10 @@ namespace Fuse.Controls
 		```
 		## Supported formats
 
-		`Video` is implemented by using the videodecoder provided by the export target and therefore supports whatever the platform supports. Be aware that Windows, OS X, Android and iOS might not share support for some formats
+		`Video` is implemented by using the videodecoder provided by the export target and therefore supports whatever the platform supports. Be aware that Windows, macOS, Android and iOS might not share support for some formats
 
 		- [Android supported formats](https://developer.android.com/guide/appendix/media-formats.html)
-		- [iOS and OS X supported formats (found under 'public.movie')](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)
+		- [iOS and macOS supported formats (found under 'public.movie')](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)
 		- [Windows supported formats](https://msdn.microsoft.com/en-us/library/cc189080%28v=vs.95%29.aspx?f=255&MSPPError=-2147217396)
 
 		## Playing from the local file system

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
@@ -8,7 +8,7 @@ using Fuse.Drawing.Primitives;
 
 namespace Fuse.Drawing
 {
-	extern(iOS||OSX)
+	extern(IOS || MAC)
 	class CoreGraphicsSurfacePath : SurfacePath
 	{
 		public IntPtr Path;
@@ -19,7 +19,7 @@ namespace Fuse.Drawing
 	[Require("source.include", "CoreGraphics/CoreGraphicsLib.h")]
 	[extern(!METAL) Require("xcode.framework", "GLKit")]
 	[extern(iOS) Require("source.include", "OpenGLES/ES2/gl.h")]
-	extern(iOS||OSX)
+	extern(IOS || MAC)
 	abstract class CoreGraphicsSurface : Surface
 	{
 		protected float _pixelsPerPoint;
@@ -248,10 +248,10 @@ namespace Fuse.Drawing
 		}
 
 		[extern(iOS) Require("xcode.framework", "UIKit")]
-		[extern(OSX) Require("source.include", "AppKit/AppKit.h")]
+		[extern(MAC) Require("source.include", "AppKit/AppKit.h")]
 		[Require("source.include", "TargetConditionals.h")]
 		[Foreign(Language.ObjC)]
-		extern(iOS||OSX) IntPtr CreateNativeImage(byte[] bytes)
+		extern(IOS || MAC) IntPtr CreateNativeImage(byte[] bytes)
 		@{
 			uArray* arr = [bytes unoArray];
 			NSData* data = [NSData dataWithBytes:arr->Ptr() length:arr->Length()];

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
@@ -227,7 +227,7 @@ namespace Fuse.Drawing
 				CGFloatSet(offsets, i, Math.Clamp(stop.Offset, 0.0f, 1.0f));
 
 				if (stop.Offset > 1.0f || stop.Offset < 0.0f)
-					Fuse.Diagnostics.UserWarning( "iOS/OSX does not support gradient stops outside of 0.0 to 1.0", stop.Offset );
+					Fuse.Diagnostics.UserWarning( "iOS/macOS does not support gradient stops outside of 0.0 to 1.0", stop.Offset );
 			}
 			_gradientBrushes[lg] = CreateLinearGradient(_context, colors, offsets, stops.Length );
 
@@ -374,7 +374,7 @@ namespace Fuse.Drawing
 				&& !_strokeWarning)
 			{
 				_strokeWarning = true;
-				Fuse.Diagnostics.UserWarning( "iOS/OSX does not support non-center alignment strokes", stroke );
+				Fuse.Diagnostics.UserWarning( "iOS/macOS does not support non-center alignment strokes", stroke );
 			}
 
 			var cgPath = path as CoreGraphicsSurfacePath;
@@ -504,7 +504,7 @@ namespace Fuse.Drawing
 			{
 				//skip M33 since Z scaling of flat objects is okay and common
 				Fuse.Diagnostics.UserWarning(
-					"iOS/OSX does not support 3d or shear transforms for vector graphics", this );
+					"iOS/macOS does not support 3d or shear transforms for vector graphics", this );
 				_transformWarn = true;
 			}
 

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
@@ -12,9 +12,9 @@ namespace Fuse.Drawing
 	[Require("xcode.framework", "CoreGraphics")]
 	[Require("source.include", "CoreGraphics/CoreGraphicsLib.h")]
 	[extern(!METAL) Require("xcode.framework", "GLKit")]
-	[extern(OSX) Require("source.include", "XliPlatform/GL.h")]
+	[extern(MAC) Require("source.include", "XliPlatform/GL.h")]
 	[extern(iOS) Require("source.include", "OpenGLES/ES2/gl.h")]
-	extern(iOS||OSX)
+	extern(IOS || MAC)
 	class GraphicsSurface : CoreGraphicsSurface
 	{
 		DrawContext _drawContext;

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/NativeSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/NativeSurface.uno
@@ -5,7 +5,7 @@ using Fuse.Drawing.Primitives;
 
 namespace Fuse.Drawing
 {
-	extern(iOS||OSX)
+	extern(IOS || MAC)
 	class NativeSurface : CoreGraphicsSurface
 	{
 

--- a/Source/Fuse.Drawing.Surface/Fuse.Drawing.Surface.unoproj
+++ b/Source/Fuse.Drawing.Surface/Fuse.Drawing.Surface.unoproj
@@ -22,7 +22,7 @@
   ],
   "includes": [
     "*",
-    "CoreGraphics/CoreGraphicsLib.h:cheader:iOS||OSX",
+    "CoreGraphics/CoreGraphicsLib.h:cheader:IOS || MAC",
     "Android/LinearGradientStore.java:java:Android",
     "Android/GraphicsSurfaceContext.java:java:Android"
   ],

--- a/Source/Fuse.Drawing.Surface/SurfaceManager.uno
+++ b/Source/Fuse.Drawing.Surface/SurfaceManager.uno
@@ -27,7 +27,7 @@ namespace Fuse.Drawing
 
 			if (c == null)
 			{
-				if defined(iOS||OSX)
+				if defined(IOS || MAC)
 					c = new GraphicsSurface();
 				else if defined(Android)
 					c = new GraphicsSurface();

--- a/Source/Fuse.FileSystem/UnifiedPaths.uno
+++ b/Source/Fuse.FileSystem/UnifiedPaths.uno
@@ -32,7 +32,7 @@ namespace Fuse.FileSystem
 		{
 			// Right now the path of the executable is used.
 			// This is probably appropriate during testing, but if we ever
-			// rebrand Fuse as a OSX or Windows desktop this should
+			// rebrand Fuse as a macOS or Windows desktop this should
 			// probably be changed.
 
 			return GetOrCreateDirectory(ref _cacheDirectory, "fs_cache");

--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -293,7 +293,7 @@ namespace Fuse.Platform
 			UIView* view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
 
 		#if defined(__IPHONE_11_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0
-			//Only on iOS11, taken care of in the GetSafeFrame code (we don't use @available in order to support older XCode version)
+			//Only on iOS11, taken care of in the GetSafeFrame code (we don't use @available in order to support older Xcode version)
 			UIEdgeInsets insets = view.safeAreaInsets;
 			*l = insets.left;
 			*t = insets.top;

--- a/Source/Fuse.PushNotifications/Docs/AppleSpecifics.md
+++ b/Source/Fuse.PushNotifications/Docs/AppleSpecifics.md
@@ -8,21 +8,21 @@ To do this you need an SSL certificate for your app.
 - Go to the Certificates Section for iOS apps
 - In the link bar on the left, under the `Identifiers` section click `App IDs`
 - Click the `+` icon in the top right to create a new App ID
-- Fill in the details, you cant use push notification with a `Wildcard App ID` so pick `Explicit App ID` and check in XCode for the app's `Bundle ID`
+- Fill in the details, you cant use push notification with a `Wildcard App ID` so pick `Explicit App ID` and check in Xcode for the app's `Bundle ID`
 - Under `App Services` enable Push notifications (and anything else you need)
 - Click `Continue` and confirm the certificate choice you made.
 
-### Syncing XCode
+### Syncing Xcode
 
-Your app is now authenticated for Push notifications. Be sure to resync your profiles in XCode before re-building your app.
+Your app is now authenticated for Push notifications. Be sure to resync your profiles in Xcode before re-building your app.
 To do this:
-- Open XCode
-- In the menu-bar choose `XCode`->`Preferences`
+- Open Xcode
+- In the menu-bar choose `Xcode`->`Preferences`
 - In the Preferences window view the `Accounts` tab
 - In the `Accounts` tab click `View Details` for the relevant Apple ID
 - Click the small refresh button in the bottom left of the `View Details` window
 
-### Sending Push Notifications to iOS from OSX
+### Sending Push Notifications to iOS from macOS
 
 For simple testing you may find that setting up a server is a bit of an overkill. To this end we recommend [NWPusher](https://github.com/noodlewerk/NWPusher). Download the binary [here](https://github.com/noodlewerk/NWPusher/releases/tag/0.6.3) and then follow the following sections from the README
 
@@ -31,5 +31,5 @@ For simple testing you may find that setting up a server is a bit of an overkill
 - Instead of reading the `Device Token` section simply add the example from above to your UX file
 - Finally, follow the `Push from OS X` Section
 
-Done, you should now be pushing notifications from OSX to iOS.
+Done, you should now be pushing notifications from macOS to iOS.
 

--- a/Source/Fuse.Reactive.Bindings/Instantiator.uno
+++ b/Source/Fuse.Reactive.Bindings/Instantiator.uno
@@ -67,7 +67,7 @@ namespace Fuse.Reactive
 
 	/* `WindowItem` and `TemplateMatch` are meant to be private to `Instantiator`.  They've been
 		outside to solve a  build error on DotNet/Windows shown on AppVeyor
-		(not reproducible on DotNet/OSX)
+		(not reproducible on DotNet/macOS)
 		UNO: https://github.com/fusetools/uno/issues/1503
 	*/
 	class WindowItem : WindowListItem

--- a/Source/Fuse.Reactive.Expressions/Device.uno
+++ b/Source/Fuse.Reactive.Expressions/Device.uno
@@ -129,7 +129,7 @@ namespace Fuse.Reactive
 			Props[NameIsAndroid] = defined(Android);
 			Props[NameIsIOS] = defined(iOS);
 
-			Props[NameIsMac] = defined(OSX);
+			Props[NameIsMac] = defined(MAC);
 			Props[NameIsWindows] = defined(Win32);
 
 			Props[NameIsPreview] = defined(Preview);

--- a/Source/Fuse.Reactive.Expressions/PlatformFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/PlatformFunctions.uno
@@ -91,11 +91,21 @@ namespace Fuse.Reactive
 	}
 
 	[UXFunction("isOSX")]
+	[Obsolete("Please use IsMacFunction instead")]
 	/** `true` if running on macOS */
 	public class IsOSXFunction : PlatformFunction
 	{
 		[UXConstructor]
 		public IsOSXFunction() : base("OSX") { }
+		protected override bool GetResult() { return defined(MAC); }
+	}
+
+	[UXFunction("isMac")]
+	/** `true` if running on macOS */
+	public class IsMacFunction : PlatformFunction
+	{
+		[UXConstructor]
+		public IsMacFunction() : base("Mac") { }
 		protected override bool GetResult() { return defined(MAC); }
 	}
 

--- a/Source/Fuse.Reactive.Expressions/PlatformFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/PlatformFunctions.uno
@@ -91,7 +91,7 @@ namespace Fuse.Reactive
 	}
 
 	[UXFunction("isOSX")]
-	/** `true` if running on OSX */
+	/** `true` if running on macOS */
 	public class IsOSXFunction : PlatformFunction
 	{
 		[UXConstructor]

--- a/Source/Fuse.Reactive.Expressions/PlatformFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/PlatformFunctions.uno
@@ -96,7 +96,7 @@ namespace Fuse.Reactive
 	{
 		[UXConstructor]
 		public IsOSXFunction() : base("OSX") { }
-		protected override bool GetResult() { return defined(OSX); }
+		protected override bool GetResult() { return defined(MAC); }
 	}
 
 	[UXFunction("isWindows")]

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -1,5 +1,5 @@
 <extensions backend="cplusplus" condition="USE_V8">
-	<require condition="OSX" linkDirectory="@('lib/OSX':path)" />
+	<require condition="MAC" linkDirectory="@('lib/OSX':path)" />
 	<require condition="WIN32" linkDirectory="@('lib/Windows':path)" />
 	<require condition="WIN32" sharedLibrary="@('lib/Windows/V8Simple.dll':path)" />
 	<require includeDirectory="@('.':path)" />

--- a/Source/Fuse.Text/README.md
+++ b/Source/Fuse.Text/README.md
@@ -9,7 +9,7 @@ that, with some care, can be used both on C++ backends and CIL backends.
 
 *Important:* After having made changes to or added any Foreign CPlusPlus
 methods, the PInvoke libraries need to be rebuilt for Windows (both X86 and
-X64) and OSX. This can be done using `uno build pinvoke -crelease`. The stuff files
+X64) and macOS. This can be done using `uno build pinvoke -crelease`. The stuff files
 containing these libs then need to be recreated and reuploaded.
 
 ## What the text goes through to be rendered

--- a/Tests/ManualTests/ManualTestingApp/DeviceInfo/DeviceInfo.ux
+++ b/Tests/ManualTests/ManualTestingApp/DeviceInfo/DeviceInfo.ux
@@ -56,7 +56,7 @@
 				<PlatformCheck Label="Android" Value="isAndroid()"/>
 				<PlatformCheck Label="Desktop" Value="isDesktop()"/>
 				<PlatformCheck Label="Windows" Value="isWindows()"/>
-				<PlatformCheck Label="macOS" Value="isOSX()"/>
+				<PlatformCheck Label="macOS" Value="isMac()"/>
 			</Grid>
 			
 			<WhileTrue Value="isDefined({=Device.osVersion})">

--- a/Tests/ManualTests/ManualTestingApp/DeviceInfo/DeviceInfo.ux
+++ b/Tests/ManualTests/ManualTestingApp/DeviceInfo/DeviceInfo.ux
@@ -56,7 +56,7 @@
 				<PlatformCheck Label="Android" Value="isAndroid()"/>
 				<PlatformCheck Label="Desktop" Value="isDesktop()"/>
 				<PlatformCheck Label="Windows" Value="isWindows()"/>
-				<PlatformCheck Label="OSX" Value="isOSX()"/>
+				<PlatformCheck Label="macOS" Value="isOSX()"/>
 			</Grid>
 			
 			<WhileTrue Value="isDefined({=Device.osVersion})">

--- a/Tests/ManualTests/ManualTestingApp/Update/UpdatePage.ux.uno
+++ b/Tests/ManualTests/ManualTestingApp/Update/UpdatePage.ux.uno
@@ -22,7 +22,7 @@ public partial class UpdatePage
 		bool noDraw = validFrame > 30;
 		
 		// `NeedsRedraw` is not used on the GraphicsView drivers
-		if defined(OSX||DotNet)
+		if defined(MAC || DOTNET)
 		{
 			var need = app.NeedsRedraw;
 		
@@ -74,7 +74,7 @@ public partial class UpdatePage
 		}
 		
 		bool waitAgain = AppBase.Current.RootViewport.ValidFrameCount < 2;
-		if defined(OSX||DotNet)
+		if defined(MAC || DOTNET)
 		{
 			waitAgain = waitAgain || AppBase.Current.NeedsRedraw;
 		}


### PR DESCRIPTION
### UX: deprecate isOSX()

This deprecates the isOSX() function. Please use isMac() instead.

### defines: OSX -> MAC

Prefer to use MAC in compile-time conditionals.

### docs: OS X -> macOS

XCode -> Xcode

Prefer to say macOS and Xcode in documentation.