### PR TITLE
Fix Android CameraView not showing on Android 13 or later because of permissions

### DIFF
--- a/Source/Fuse.Controls.CameraView/Android/CameraView.uno
+++ b/Source/Fuse.Controls.CameraView/Android/CameraView.uno
@@ -65,11 +65,27 @@ namespace Fuse.Controls.Android
 			public InitialLoadClosure(CameraFacing facing)
 			{
 				_facing = facing;
-				Permissions.Request(new PlatformPermission[] {
-					Permissions.Android.CAMERA,
-					Permissions.Android.RECORD_AUDIO,
-					Permissions.Android.WRITE_EXTERNAL_STORAGE
-				}).Then(OnPermissionsPerimtted, Reject);
+				if (AndroidProperties.BuildVersion >= 33)
+				{
+					var permissions = new PlatformPermission[]
+					{
+						Permissions.Android.CAMERA,
+						Permissions.Android.READ_MEDIA_IMAGES,
+						Permissions.Android.READ_MEDIA_VIDEO,
+						Permissions.Android.READ_MEDIA_AUDIO
+					};
+					Permissions.Request(permissions).Then(OnPermissionsPerimtted, Reject);
+				}
+				else
+				{
+					var permissions = new PlatformPermission[]
+					{
+						Permissions.Android.CAMERA,
+						Permissions.Android.WRITE_EXTERNAL_STORAGE,
+						Permissions.Android.READ_EXTERNAL_STORAGE
+					};
+					Permissions.Request(permissions).Then(OnPermissionsPerimtted, Reject);
+				}
 			}
 
 			void OnPermissionsPerimtted(PlatformPermission[] permission)

--- a/Source/Fuse.Controls.Video/Android/VideoPlayer.uno
+++ b/Source/Fuse.Controls.Video/Android/VideoPlayer.uno
@@ -244,6 +244,7 @@ namespace Fuse.Controls.VideoImpl.Android
 					if (rotation != null) {
 						return java.lang.Integer.parseInt(rotation);
 					}
+					afd.close();
 				}
 				catch (Exception e) { /* We do not care if this fails */ }
 			}
@@ -434,6 +435,7 @@ namespace Fuse.Controls.VideoImpl.Android
 			{
 				// (ﾉಥДಥ)ﾉ︵┻━┻･/
 				player.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+				afd.close();
 			}
 			// (ﾉಥДಥ)ﾉ︵┻━┻･/
 			catch (Exception e)


### PR DESCRIPTION
This PR also fix memory leak on `<Video>` component reported on android Logcat because FileDescriptor is not closed.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
