### PR TITLE
Native ScrollView feature parity with the Graphics Mode

### DIFF
--- a/Source/Fuse.Controls.Native/Android/Java/FuseScrollView.java
+++ b/Source/Fuse.Controls.Native/Android/Java/FuseScrollView.java
@@ -14,6 +14,7 @@ public class FuseScrollView extends FrameLayout implements ScrollEventHandler {
 	private GestureDetector mGestureDectector;
 
 	private boolean _isHorizontal = false;
+	private boolean isScrolling = true;
 
 	public FuseScrollView(android.content.Context context) {
 		super(context);
@@ -63,6 +64,12 @@ public class FuseScrollView extends FrameLayout implements ScrollEventHandler {
 
 	public void setScrollEventHandler(ScrollEventHandler scrollEventHandler) {
 		_scrollEventHandler = scrollEventHandler;
+	}
+
+	ScrollInteractionEventHandler _scrollInteractionHandler;
+
+	public void setScrollInteractionEventHandler(ScrollInteractionEventHandler scrollInteractionHandler) {
+		_scrollInteractionHandler = scrollInteractionHandler;
 	}
 
 	public void setIsHorizontal(boolean isHorizontal) {
@@ -180,6 +187,27 @@ public class FuseScrollView extends FrameLayout implements ScrollEventHandler {
 
 	@Override
 	public boolean onTouchEvent(MotionEvent ev) {
-		return mGestureDectector.onTouchEvent(ev);
+		if (this.isScrolling) {
+			if (_scrollInteractionHandler != null) {
+				if (ev.getAction() == MotionEvent.ACTION_DOWN)
+					_scrollInteractionHandler.onInteractionChanged(true);
+				else if (ev.getAction() == MotionEvent.ACTION_UP || ev.getAction() == MotionEvent.ACTION_CANCEL)
+					_scrollInteractionHandler.onInteractionChanged(false);
+			}
+            return mGestureDectector.onTouchEvent(ev);
+        } else {
+            return false;
+        }
 	}
+
+	public void smoothScrollTo(int x, int y) {
+		if (_currentScrollView instanceof VerticalScrollView)
+			((VerticalScrollView)_currentScrollView).smoothScrollTo(x, y);
+		else
+			((HorizontalScrollView)_currentScrollView).smoothScrollTo(x, y);
+	}
+
+	public void setScrolling(boolean isScrolling) {
+        this.isScrolling = isScrolling;
+    }
 }

--- a/Source/Fuse.Controls.Native/Android/Java/HorizontalScrollView.java
+++ b/Source/Fuse.Controls.Native/Android/Java/HorizontalScrollView.java
@@ -4,6 +4,8 @@ public class HorizontalScrollView extends android.widget.HorizontalScrollView {
 
 	public HorizontalScrollView(android.content.Context context) {
 		super(context);
+		this.setVerticalScrollBarEnabled(false);
+		this.setHorizontalScrollBarEnabled(false);
 	}
 
 	ScrollEventHandler _scrollEventHandler;

--- a/Source/Fuse.Controls.Native/Android/Java/ScrollInteractionEventHandler.java
+++ b/Source/Fuse.Controls.Native/Android/Java/ScrollInteractionEventHandler.java
@@ -1,0 +1,5 @@
+package com.fuse.android.views;
+
+public interface ScrollInteractionEventHandler {
+    public void onInteractionChanged(boolean isInteracting);
+}

--- a/Source/Fuse.Controls.Native/Android/Java/VerticalScrollView.java
+++ b/Source/Fuse.Controls.Native/Android/Java/VerticalScrollView.java
@@ -4,6 +4,8 @@ public class VerticalScrollView extends android.widget.ScrollView {
 
 	public VerticalScrollView(android.content.Context context) {
 		super(context);
+		this.setVerticalScrollBarEnabled(false);
+		this.setHorizontalScrollBarEnabled(false);
 	}
 
 	ScrollEventHandler _scrollEventHandler;

--- a/Source/Fuse.Controls.Native/Fuse.Controls.Native.unoproj
+++ b/Source/Fuse.Controls.Native/Fuse.Controls.Native.unoproj
@@ -40,6 +40,7 @@
     "iOS/ContainerView.h:objcheader:iOS",
     "iOS/ContainerView.mm:objcsource:iOS",
     "Android/Java/ScrollEventHandler.java:java:Android",
+    "Android/Java/ScrollInteractionEventHandler.java:java:Android",
     "Android/Java/FuseScrollView.java:java:Android",
     "Android/Java/HorizontalScrollView.java:java:Android",
     "Android/Java/VerticalScrollView.java:java:Android",

--- a/Source/Fuse.Controls.Native/Interfaces.uno
+++ b/Source/Fuse.Controls.Native/Interfaces.uno
@@ -119,7 +119,9 @@ namespace Fuse.Controls.Native
 	public interface IScrollView : IView
 	{
 		float2 ScrollPosition { set; }
+		float2 Goto { set; }
 		ScrollDirections AllowedScrollDirections { set; }
+		bool UserScroll { set; }
 	}
 
 	public interface IScrollViewHost
@@ -127,6 +129,7 @@ namespace Fuse.Controls.Native
 		float PixelsPerPoint { get; }
 		float2 ContentSize { get; }
 		void OnScrollPositionChanged(float2 newScrollPosition);
+		void OnInteractionChanged(bool isInteracting);
 	}
 
 	public interface INativeViewRenderer : IDisposable

--- a/Source/Fuse.Controls.Native/iOS/Helpers.h
+++ b/Source/Fuse.Controls.Native/iOS/Helpers.h
@@ -71,7 +71,10 @@
 @interface ScrollViewDelegate : NSObject<UIScrollViewDelegate>
 
 @property (copy) void (^didScrollCallback)(id);
+@property (copy) void (^didInteractinglCallback)(BOOL);
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView;
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView;
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate;
 
 @end
 

--- a/Source/Fuse.Controls.Native/iOS/Helpers.mm
+++ b/Source/Fuse.Controls.Native/iOS/Helpers.mm
@@ -170,6 +170,16 @@ static id currentFirstResponder;
 	[self didScrollCallback](scrollView);
 }
 
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
+{
+	[self didInteractinglCallback](YES);
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
+{
+	[self didInteractinglCallback](NO);
+}
+
 @end
 
 @implementation UIControlEventHandler

--- a/Source/Fuse.Controls.ScrollView/ScrollView.Native.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.Native.uno
@@ -22,6 +22,19 @@ namespace Fuse.Controls
 			SetScrollPosition(newScrollPosition, null);
 		}
 
+		void IScrollViewHost.OnInteractionChanged(bool isInteracting)
+		{
+			if (isInteracting)
+				BeginInteraction(_interactionId, OnCancelInteraction);
+			else
+				EndInteraction(_interactionId);
+		}
+
+		void OnCancelInteraction()
+		{
+			EndInteraction(_interactionId);
+		}
+
 		float2 IScrollViewHost.ContentSize
 		{
 			get
@@ -44,6 +57,7 @@ namespace Fuse.Controls
 			if (nsv != null)
 			{
 				nsv.AllowedScrollDirections = AllowedScrollDirections;
+				nsv.UserScroll = UserScroll;
 			}
 		}
 	}

--- a/Source/Fuse.Controls.ScrollView/Scroller.uno
+++ b/Source/Fuse.Controls.ScrollView/Scroller.uno
@@ -57,7 +57,6 @@ namespace Fuse.Gestures
 			//Set in ugly fashion, required by https://github.com/fusetools/fuselibs-private/issues/870
 			//previously the ScrollView would just listen for added children, but this appears safer
 			_scrollable._scroller = this;
-			_scrollable.RequestBringIntoView += OnRequestBringIntoView;
 			_scrollable.ScrollPositionChanged += OnScrollPositionChanged;
 			_region = _scrollable.Motion.AcquireSimulation();
 			UpdatePointerEvents();
@@ -68,7 +67,6 @@ namespace Fuse.Gestures
 			StopInvalidateVisual();
 
 			_scrollable.RemovePropertyListener(this);
-			_scrollable.RequestBringIntoView -= OnRequestBringIntoView;
 			_scrollable.ScrollPositionChanged -= OnScrollPositionChanged;
 			_scrollable._scroller = null;
 
@@ -315,25 +313,6 @@ namespace Fuse.Gestures
 			//any already active region will respond to the updated bounds on its own
 			if (_region != null && _region.IsStatic && !_region.IsUser)
 				Goto(_scrollable.ScrollPosition);
-		}
-
-		Visual _pendingBringIntoView;
-		void OnRequestBringIntoView(object sender, RequestBringIntoViewArgs args)
-		{
-			//defer to post layout and post input
-			_pendingBringIntoView = args.Visual;
-			UpdateManager.AddDeferredAction( PerformBringIntoView, UpdateStage.Layout,
-				LayoutPriority.Post);
-		}
-
-		void PerformBringIntoView()
-		{
-			if (_pendingBringIntoView == null || !_pendingBringIntoView.IsRootingCompleted)
-				return;
-
-			var pos = _scrollable.GetVisualScrollPosition(_pendingBringIntoView);
-			Goto(pos);
-        	_pendingBringIntoView = null;
 		}
 
 		public void Goto( float2 position )

--- a/Source/Fuse.Controls.Video/Android/VideoPlayer.uno
+++ b/Source/Fuse.Controls.Video/Android/VideoPlayer.uno
@@ -300,7 +300,10 @@ namespace Fuse.Controls.VideoImpl.Android
 		Java.Object CreateMediaPlayer(Java.Object surfaceHandle)
 		@{
 			android.media.MediaPlayer player = new android.media.MediaPlayer();
-			player.setAudioStreamType(android.media.AudioManager.STREAM_MUSIC);
+			if (android.os.Build.VERSION.SDK_INT >= 21)
+				player.setAudioAttributes(new android.media.AudioAttributes.Builder().setContentType(android.media.AudioAttributes.CONTENT_TYPE_MUSIC).build());
+			else
+				player.setAudioStreamType(android.media.AudioManager.STREAM_MUSIC);
 			player.setOnPreparedListener(new android.media.MediaPlayer.OnPreparedListener() {
 				public void onPrepared(android.media.MediaPlayer mp) {
 					@{Fuse.Controls.VideoImpl.Android.MediaPlayer:of(_this).OnPrepared():call()};
@@ -463,7 +466,23 @@ namespace Fuse.Controls.VideoImpl.Android
 			if (!player.isPlaying())
 			{
 				android.media.AudioManager am = (android.media.AudioManager)com.fuse.Activity.getRootActivity().getSystemService(android.content.Context.AUDIO_SERVICE);
-				am.requestAudioFocus(null, android.media.AudioManager.STREAM_MUSIC, android.media.AudioManager.AUDIOFOCUS_GAIN);
+				if (android.os.Build.VERSION.SDK_INT >= 21)
+				{
+					// Initialize the audio attributes
+					android.media.AudioAttributes playbackAttributes = new android.media.AudioAttributes.Builder()
+						.setUsage(android.media.AudioAttributes.USAGE_MEDIA)
+						.setContentType(android.media.AudioAttributes.CONTENT_TYPE_MUSIC)
+						.build();
+
+					// Initialize the audio focus request
+					android.media.AudioFocusRequest focusRequest = new android.media.AudioFocusRequest.Builder(android.media.AudioManager.AUDIOFOCUS_GAIN)
+						.setAudioAttributes(playbackAttributes)
+						.build();
+					am.requestAudioFocus(focusRequest);
+
+				}
+				else
+					am.requestAudioFocus(null, android.media.AudioManager.STREAM_MUSIC, android.media.AudioManager.AUDIOFOCUS_GAIN);
 				player.start();
 			}
 		@}

--- a/Source/Fuse.Nodes/Visual.Layout.uno
+++ b/Source/Fuse.Nodes/Visual.Layout.uno
@@ -518,18 +518,18 @@ namespace Fuse
 			@advanced */
 		public event RequestBringIntoViewHandler RequestBringIntoView;
 
-        	internal protected virtual void OnBringIntoView(Visual elm)
-        	{
-	        	if (RequestBringIntoView != null)
-	        		RequestBringIntoView(this, new RequestBringIntoViewArgs(elm));
+		internal protected virtual void OnBringIntoView(Visual elm)
+		{
+			if (RequestBringIntoView != null)
+				RequestBringIntoView(this, new RequestBringIntoViewArgs(elm));
 
-        		if (Parent != null)
-        			Parent.OnBringIntoView(elm);
-        	}
+			if (Parent != null)
+				Parent.OnBringIntoView(elm);
+		}
 
-        	public void BringIntoView()
-        	{
-	        	OnBringIntoView(this);
-        	}
+		public void BringIntoView()
+		{
+			OnBringIntoView(this);
+		}
 	}
 }


### PR DESCRIPTION
This PR makes:
- `UserScroll` Property works on native platform scrollView
-  `ScrollTo` or `Goto` action works on native platform scrollview
-  `BringIntoView` action works on native platform scrollview
-  `WhileInteracting` trigger works on native platform

Silent warning and deprecated on android media player