### PR TITLE
iOS fix crash bugs on removing shadow

### DIFF
--- a/Source/Fuse.Controls.CameraView/VideoTools.uno
+++ b/Source/Fuse.Controls.CameraView/VideoTools.uno
@@ -62,32 +62,23 @@ namespace Fuse.VideoTools
 
 		extern (iOS) internal class iOSVideoTools
 		{
-			[Require("xcode.framework", "AssetsLibrary")]
-			[Require("source.include", "AssetsLibrary/AssetsLibrary.h")]
+			[Require("xcode.framework", "Photos")]
+			[Require("source.include", "Photos/PHPhotoLibrary.h")]
+			[Require("source.include", "Photos/PHAssetChangeRequest.h")]
 			[Foreign(Language.ObjC)]
 			extern (iOS) public static bool SaveVideo(string outputFileURL)
 			@{
 				NSURL *url = [NSURL URLWithString:outputFileURL];
-				ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
-				if ([library videoAtPathIsCompatibleWithSavedPhotosAlbum:url])
-				{
-					[library writeVideoAtPathToSavedPhotosAlbum:url
-											completionBlock:^(NSURL *assetURL, NSError *error)
-					{
-						[library writeVideoAtPathToSavedPhotosAlbum:url
-												completionBlock:^(NSURL *assetURL, NSError *error)
-						{
-							if (error)
-							{
-							}
-						}];
-					}];
-				}
-				else
-				{
-					return false;
-				}
-
+				[[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+						PHAssetChangeRequest *changeRequest = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:url];
+						NSLog(@"%@", changeRequest.description);
+				} completionHandler:^(BOOL success, NSError *error) {
+					if (success) {
+						NSLog(@"saved down");
+					} else {
+						NSLog(@"something wrong %@", error.localizedDescription);
+					}
+				}];
 				return true;
 			@}
 		}

--- a/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
+++ b/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
@@ -290,7 +290,10 @@ namespace Fuse.Controls
 		static extern(iOS) void RemoveDecorationInternal(ObjC.Object viewHandle)
 		@{
 			UIView * view = (UIView *)viewHandle;
-			view.layer.sublayers = nil;
+			view.layer.shadowColor = nil;
+			view.layer.shadowOpacity = 0;
+			view.layer.shadowRadius = 0;
+			view.layer.shadowOffset = CGSizeMake(0, 0);
 		@}
 
 		[Foreign(Language.Java)]


### PR DESCRIPTION
Fix crash `EXC_BAD_ACCESS` when using `<Shadow />` behavior on `NativeViewHosts` if the shadow removed.

This PR also include fix iOS deprecated warning when saving video to camera roll using `FuseJS/VideoTools` because of old `ALAssetsLibrary` that will be removed when iOS 18 come out.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
