### PR TITLE
Native Slider Android: fix bug recursive setting value

### DIFF
--- a/Source/Fuse.Controls.Native/Android/Slider.uno
+++ b/Source/Fuse.Controls.Native/Android/Slider.uno
@@ -65,8 +65,8 @@ namespace Fuse.Controls.Native.Android
 					rel = Math.Round(rel/us) * us;
 					SetProgress(Handle, rel * 1000);
 				}
+				_host.OnProgressChanged(rel);
 			}
-			_host.OnProgressChanged(rel);
 		}
 
 		public override void Dispose()

--- a/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
@@ -137,7 +137,7 @@ namespace Fuse.Controls
 			}
 
 			var rv = RangeView;
-			if (rv != null && origin != rv)
+			if (rv != null && origin != null && origin != rv )
 			{
 				rv.Progress = ValueToRelative(value);
 			}


### PR DESCRIPTION
On Android, when toying with `Video` Control using `Progress` property and bind it with Sliders Value, because of the two-way binding, the Sliders value always keep Progress value of Video control to restart from beginning so that the video wont play. To fix the issue, we only dispatch notification of progress changes only when triggered by user and not by the value binding.

test case:
```
<DockPanel>
  <Slider ux:Name="_slider" Minimum="0" Maximum="1" Dock="Top" />
  <Video ux:Name="_video" StretchMode="Fill" IsLooping="true" Url="https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" Progress="{Property _slider.Value}">
</DockPanel>
```

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
