### PR TITLE
android fix crash on layout transformation

### DIFF
--- a/Source/Fuse.Nodes/ViewHandle.Android.uno
+++ b/Source/Fuse.Nodes/ViewHandle.Android.uno
@@ -251,11 +251,16 @@ namespace Fuse.Controls.Native
 			android.view.View view = (android.view.View)@{Fuse.Controls.Native.ViewHandle:of(_this).NativeHandle:get()};
 			view.setPivotX(0);
 			view.setPivotY(0);
-			view.setScaleX(scaleX);
-			view.setScaleY(scaleY);
-			view.setRotation(rotation);
-			view.setRotationX(rotationX);
-			view.setRotationY(rotationY);
+			if (!Float.isNaN(scaleX))
+				view.setScaleX(scaleX);
+			if (!Float.isNaN(scaleY))
+				view.setScaleY(scaleY);
+			if (!Float.isNaN(rotation))
+				view.setRotation(rotation);
+			if (!Float.isNaN(rotationX))
+				view.setRotationX(rotationX);
+			if (!Float.isNaN(rotationY))
+				view.setRotationY(rotationY);
 		@}
 
 		public virtual float2 Measure(LayoutParams lp, float density)


### PR DESCRIPTION
On some rare case, Application will go crash if we do component transformation such as `Scale`, `Rotate` because of bad calculation (Float.NaN), we need more investigation on how it came like that. but in meanwhile we add sanitary check before  transformation

![error](https://github.com/user-attachments/assets/2c9c8c07-dd87-4dae-b66e-c32daec82015)


This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
