### PR TITLE
Implement native Scrollview snap min/max and Android bounce scroll

### DIFF
--- a/Source/Fuse.Controls.Native/Android/Java/FuseScrollView.java
+++ b/Source/Fuse.Controls.Native/Android/Java/FuseScrollView.java
@@ -1,5 +1,6 @@
 package com.fuse.android.views;
 
+import android.view.animation.Interpolator;
 import android.widget.FrameLayout;
 import android.view.View;
 import android.view.ViewGroup;
@@ -187,11 +188,40 @@ public class FuseScrollView extends FrameLayout implements ScrollEventHandler {
         this.isScrolling = isScrolling;
     }
 
+	public void setDisableBounceStart(boolean disableBounceStart) {
+		if (_currentScrollView instanceof VerticalScrollView)
+			((VerticalScrollView)_currentScrollView).setDisableBounceStart(!disableBounceStart);
+		else
+			((HorizontalScrollView)_currentScrollView).setDisableBounceStart(!disableBounceStart);
+	}
+
+	public void setDisableBounceEnd(boolean disableBounceEnd) {
+		if (_currentScrollView instanceof VerticalScrollView)
+			((VerticalScrollView)_currentScrollView).setDisableBounceEnd(!disableBounceEnd);
+		else
+			((HorizontalScrollView)_currentScrollView).setDisableBounceEnd(!disableBounceEnd);
+	}
+
 	private void setupContainer() {
 		_container = new android.widget.FrameLayout(com.fuse.Activity.getRootActivity());
 		_container.setFocusable(true);
 		_container.setFocusableInTouchMode(true);
 		_container.setLayoutParams(new android.widget.LinearLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.WRAP_CONTENT));
 		_currentScrollView.addView(_container);
+	}
+
+	public static class DefaultQuartOutInterpolator implements Interpolator {
+
+		@Override
+		public float getInterpolation(float input) {
+			return (float) (1.0f - Math.pow(1 - input, 4));
+		}
+	}
+
+	public interface OnOverScrollListener {
+		/**
+		 * @param fromStart LTR, the left is start; RTL, the right is start.
+		 */
+		void onOverScrolling(boolean fromStart, int overScrolledDistance);
 	}
 }

--- a/Source/Fuse.Controls.Native/Android/Java/VerticalScrollView.java
+++ b/Source/Fuse.Controls.Native/Android/Java/VerticalScrollView.java
@@ -1,11 +1,163 @@
 package com.fuse.android.views;
 
+import android.animation.ObjectAnimator;
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.animation.Interpolator;
+
+import androidx.annotation.NonNull;
+
 public class VerticalScrollView extends android.widget.ScrollView {
 
-	public VerticalScrollView(android.content.Context context) {
+	private static final int MAX_Y_OVERSCROLL_DISTANCE = 50;
+	private static final float DEFAULT_DAMPING_COEFFICIENT = 4.0f;
+	private static final long DEFAULT_BOUNCE_DELAY = 400;
+
+	private float mDamping;
+	private boolean mIncrementalDamping;
+	private long mBounceDelay;
+	private boolean mDisableBounceStart;
+	private boolean mDisableBounceEnd;
+
+	private final Interpolator mInterpolator;
+	private View mChildView;
+	private float mStart;
+	private int mOverScrolledDistance;
+	private ObjectAnimator mAnimator;
+	private FuseScrollView.OnOverScrollListener mOverScrollListener;
+	private int mMaxYOverscrollDistance;
+
+	public VerticalScrollView(Context context) {
 		super(context);
+		this.mDamping = DEFAULT_DAMPING_COEFFICIENT;
+		this.mIncrementalDamping = true;
+		this.mBounceDelay = DEFAULT_BOUNCE_DELAY;
+
 		this.setVerticalScrollBarEnabled(false);
 		this.setHorizontalScrollBarEnabled(false);
+		this.setFillViewport(true);
+
+		this.mInterpolator = new FuseScrollView.DefaultQuartOutInterpolator();
+		initBounceScrollView(context);
+	}
+
+	private void initBounceScrollView(Context context) {
+		final DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+		final float density = metrics.density;
+		this.mMaxYOverscrollDistance = (int) (density * MAX_Y_OVERSCROLL_DISTANCE);
+	}
+
+	@Override
+	protected boolean overScrollBy(int deltaX, int deltaY, int scrollX, int scrollY,
+									int scrollRangeX, int scrollRangeY,
+									int maxOverScrollX, int maxOverScrollY,
+									boolean isTouchEvent) {
+		int offset = mChildView.getMeasuredHeight() - getHeight();
+		offset = Math.max(offset, 0);
+		int overScrollDistance = mMaxYOverscrollDistance;
+		if (deltaY < 0 && scrollY == 0 && mDisableBounceStart)
+			overScrollDistance = 0;
+		else if (deltaY > 0 && scrollY == offset && mDisableBounceEnd)
+			overScrollDistance = 0;
+		return super.overScrollBy(deltaX, deltaY, scrollX, scrollY,
+									scrollRangeX, scrollRangeY,
+									maxOverScrollX, overScrollDistance,
+									isTouchEvent);
+	}
+
+	@Override
+	public boolean onInterceptTouchEvent(MotionEvent ev) {
+		if (this.mChildView == null && getChildCount() > 0 || mChildView != getChildAt(0)) {
+			this.mChildView = getChildAt(0);
+		}
+		return super.onInterceptTouchEvent(ev);
+	}
+
+	@Override
+	public boolean onTouchEvent(MotionEvent ev) {
+		if (this.mChildView == null)
+			return super.onTouchEvent(ev);
+
+		switch (ev.getActionMasked()) {
+			case MotionEvent.ACTION_DOWN:
+				this.mStart = ev.getY();
+
+				break;
+			case MotionEvent.ACTION_MOVE:
+				float now, delta;
+				int dampingDelta;
+
+				now = ev.getY();
+				delta = mStart - now;
+				dampingDelta = (int) (delta / calculateDamping());
+				this.mStart = now;
+
+				if (canMove(dampingDelta)) {
+					this.mOverScrolledDistance += dampingDelta;
+					this.mChildView.setTranslationY(-this.mOverScrolledDistance);
+					if (this.mOverScrollListener != null) {
+						this.mOverScrollListener.onOverScrolling(this.mOverScrolledDistance <= 0, Math.abs(this.mOverScrolledDistance));
+					}
+				}
+
+				break;
+			case MotionEvent.ACTION_UP:
+			case MotionEvent.ACTION_CANCEL:
+				this.mOverScrolledDistance = 0;
+
+				cancelAnimator();
+				this.mAnimator = ObjectAnimator.ofFloat(mChildView, View.TRANSLATION_Y, 0);
+				this.mAnimator.setDuration(mBounceDelay).setInterpolator(mInterpolator);
+				if (this.mOverScrollListener != null) {
+					this.mAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+						@Override
+						public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+							float value = (float) animation.getAnimatedValue();
+							mOverScrollListener.onOverScrolling(value <= 0, Math.abs((int) value));
+						}
+					});
+				}
+				this.mAnimator.start();
+
+				break;
+		}
+
+		return super.onTouchEvent(ev);
+	}
+
+	private float calculateDamping() {
+		float ratio;
+		ratio = Math.abs(mChildView.getTranslationY()) / mChildView.getMeasuredHeight();
+		ratio += 0.2F;
+		if (this.mIncrementalDamping) {
+			return this.mDamping / (1.0f - (float) Math.pow(ratio, 2));
+		} else {
+			return this.mDamping;
+		}
+	}
+
+	private boolean canMove(int delta) {
+		return delta < 0 ? canMoveFromStart() : canMoveFromEnd();
+	}
+
+	private boolean canMoveFromStart() {
+		return getScrollY() == 0 && !isDisableBounceStart();
+	}
+
+	private boolean canMoveFromEnd() {
+		int offset = mChildView.getMeasuredHeight() - getHeight();
+		offset = Math.max(offset, 0);
+		return getScrollY() == offset && !isDisableBounceEnd();
+	}
+
+	private void cancelAnimator() {
+		if (this.mAnimator != null && this.mAnimator.isRunning()) {
+			this.mAnimator.cancel();
+		}
 	}
 
 	ScrollEventHandler _scrollEventHandler;
@@ -34,6 +186,22 @@ public class VerticalScrollView extends android.widget.ScrollView {
 			canvas.clipRect(rect);
 		}
 		super.draw(canvas);
+	}
+
+	public boolean isDisableBounceStart() {
+		return mDisableBounceStart;
+	}
+
+	public void setDisableBounceStart(boolean disableBounceStart) {
+		this.mDisableBounceStart = disableBounceStart;
+	}
+
+	public boolean isDisableBounceEnd() {
+		return mDisableBounceEnd;
+	}
+
+	public void setDisableBounceEnd(boolean disableBounceEnd) {
+		this.mDisableBounceEnd = disableBounceEnd;
 	}
 
 }

--- a/Source/Fuse.Controls.Native/Android/ScrollView.uno
+++ b/Source/Fuse.Controls.Native/Android/ScrollView.uno
@@ -66,6 +66,28 @@ namespace Fuse.Controls.Native.Android
 		}
 
 		[Foreign(Language.Java)]
+		void SetSnapMinTransform(Java.Object handle, bool value)
+		@{
+			((com.fuse.android.views.FuseScrollView)handle).setDisableBounceStart(value);
+		@}
+
+		[Foreign(Language.Java)]
+		void SetSnapMaxTransform(Java.Object handle, bool value)
+		@{
+			((com.fuse.android.views.FuseScrollView)handle).setDisableBounceEnd(value);
+		@}
+
+		public bool SnapMinTransform
+		{
+			set { SetSnapMinTransform(NativeHandle, value); }
+		}
+
+		public bool SnapMaxTransform
+		{
+			set { SetSnapMaxTransform(NativeHandle, value); }
+		}
+
+		[Foreign(Language.Java)]
 		void SetUserScroll(Java.Object handle, bool isScroll)
 		@{
 			((com.fuse.android.views.FuseScrollView)handle).setScrolling(isScroll);

--- a/Source/Fuse.Controls.Native/Interfaces.uno
+++ b/Source/Fuse.Controls.Native/Interfaces.uno
@@ -137,6 +137,8 @@ namespace Fuse.Controls.Native
 		float2 Goto { set; }
 		ScrollDirections AllowedScrollDirections { set; }
 		bool UserScroll { set; }
+		bool SnapMinTransform { set; }
+		bool SnapMaxTransform { set; }
 	}
 
 	public interface IScrollViewHost

--- a/Source/Fuse.Controls.ScrollView/ScrollView.Native.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.Native.uno
@@ -58,6 +58,8 @@ namespace Fuse.Controls
 			{
 				nsv.AllowedScrollDirections = AllowedScrollDirections;
 				nsv.UserScroll = UserScroll;
+				nsv.SnapMinTransform = SnapMinTransform;
+				nsv.SnapMaxTransform = SnapMaxTransform;
 			}
 		}
 	}


### PR DESCRIPTION
- Implement Bounce Effect on Android Native ScrollView in order to make SnapMin/MaxTransform works properly on Android.
- `SnapMinTransform` and `SnapMaxTransform` property now works on Native ScrollView both on Android and iOS,

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
